### PR TITLE
Add note button to posts page

### DIFF
--- a/NoteBookmark.BlazorApp/Components/Layout/MainLayout.razor
+++ b/NoteBookmark.BlazorApp/Components/Layout/MainLayout.razor
@@ -24,3 +24,5 @@
     <a href="" class="reload">Reload</a>
     <a class="dismiss">🗙</a>
 </div>
+
+<FluentToastContainer />

--- a/NoteBookmark.BlazorApp/Components/Layout/NavMenu.razor
+++ b/NoteBookmark.BlazorApp/Components/Layout/NavMenu.razor
@@ -9,7 +9,6 @@
             <FluentNavLink Href="counter" Icon="@(new Icons.Regular.Size20.NumberSymbolSquare())" IconColor="Color.Accent">Counter</FluentNavLink>
             <FluentNavLink Href="summaries" Icon="@(new Icons.Regular.Size20.BookNumber())" IconColor="Color.Accent">Summaries</FluentNavLink>
             <FluentNavLink Href="posts" Icon="@(new Icons.Regular.Size20.Glasses())" IconColor="Color.Accent">Posts</FluentNavLink>
-            <FluentNavLink Href="note" Icon="@(new Icons.Regular.Size20.Note())" IconColor="Color.Accent">Note</FluentNavLink>
         </FluentNavMenu>
     </nav>
 </div>

--- a/NoteBookmark.BlazorApp/Components/Pages/Note.razor
+++ b/NoteBookmark.BlazorApp/Components/Pages/Note.razor
@@ -2,6 +2,9 @@
 @page "/note/{postId}"
 @using NoteBookmark.Domain
 @inject PostNoteClient client
+@inject IToastService toastService
+@inject IJSRuntime jsRuntime
+
 @rendermode InteractiveServer
 
 <PageTitle>Note</PageTitle>
@@ -29,7 +32,7 @@
 
 </EditForm>
 
-<FluentToastContainer />
+
 
 @code {
     [Parameter]
@@ -52,11 +55,11 @@
         await client.CreateNote(note);
 
         ShowConfirmationMessage();
+        await jsRuntime.InvokeVoidAsync("open", $"/posts");
     }
 
     private void ShowConfirmationMessage()
     {
-        var toastService = new FluentToastService();
-        toastService.ShowToast("Note created successfully!", ToastType.Success);
+        toastService.ShowSuccess("Note created successfully!");
     }
 }

--- a/NoteBookmark.BlazorApp/Components/Pages/Note.razor
+++ b/NoteBookmark.BlazorApp/Components/Pages/Note.razor
@@ -1,4 +1,5 @@
 @page "/note"
+@page "/note/{postId}"
 @using NoteBookmark.Domain
 @inject PostNoteClient client
 @rendermode InteractiveServer
@@ -22,27 +23,27 @@
             <FluentValidationMessage For="@(() => note.Tags)" />
         </div>
 
-        <div>
-            <FluentTextField Name="PostId" Label="Post ID" @bind-Value="note.PostId" Required="true" />
-            <FluentValidationMessage For="@(() => note.PostId)" />
-        </div>
-
         <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Accent">Submit</FluentButton>
 
     </FluentStack>
 
 </EditForm>
 
-
-@* <FluentForm Model="@note" OnValidSubmit="@HandleValidSubmit">
-    <FluentTextField Label="Comment" @bind-Value="note.Comment" Required="true" />
-    <FluentTextField Label="Tags" @bind-Value="note.Tags" />
-    <FluentTextField Label="Post ID" @bind-Value="note.PostId" Required="true" />
-    <FluentButton Type="ButtonType.Submit">Submit</FluentButton>
-</FluentForm>  *@
+<FluentToastContainer />
 
 @code {
+    [Parameter]
+    public string? postId { get; set; }
+
     private Domain.Note note = new Domain.Note();
+
+    protected override void OnInitialized()
+    {
+        if (!string.IsNullOrEmpty(postId))
+        {
+            note.PostId = postId;
+        }
+    }
 
     private async Task HandleValidSubmit()
     {
@@ -50,5 +51,12 @@
 
         await client.CreateNote(note);
 
+        ShowConfirmationMessage();
+    }
+
+    private void ShowConfirmationMessage()
+    {
+        var toastService = new FluentToastService();
+        toastService.ShowToast("Note created successfully!", ToastType.Success);
     }
 }

--- a/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
+++ b/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
@@ -1,4 +1,4 @@
-﻿@page "/posts"
+@page "/posts"
 @using NoteBookmark.Domain
 @inject PostNoteClient client
 @inject IJSRuntime jsRuntime
@@ -14,11 +14,14 @@
 }
 else
 {
-    <FluentDataGrid Id="postgrid" Items="@posts" >
+    <FluentDataGrid Id="postgrid" Items="@posts">
         <PropertyColumn Title="Title" Property="@(c => c!.Title)" Sortable="true"/>
         <PropertyColumn Title="Published" Property="@(c => (c!.Date_published ?? "0000-00-00").Substring(0,10))"  Sortable="true" SortBy="@defSort" IsDefaultSortColumn="true"/>
         <TemplateColumn>
-            <FluentButton OnClick="@(async () => await OpenUrlInNewWindow(context!.Url))">...</FluentButton>
+            <FluentButton OnClick="@(async () => await OpenUrlInNewWindow(context!.Url))">Open</FluentButton>
+            <FluentButton OnClick="@(async () => await CreateNoteForPost(context!.RowKey))">
+                <FluentIcon Value="@(new Icons.Regular.Size20.NoteAdd())" Color="Color.Accent" />
+            </FluentButton>
         </TemplateColumn>
     </FluentDataGrid>
 }
@@ -36,5 +39,10 @@ else
     private async Task OpenUrlInNewWindow(string? url)
     {
         await jsRuntime.InvokeVoidAsync("open", url, "_blank");
+    }
+
+    private async Task CreateNoteForPost(string postId)
+    {
+        await jsRuntime.InvokeVoidAsync("open", $"/note?postId={postId}", "_self");
     }
 }

--- a/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
+++ b/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
@@ -24,6 +24,8 @@ else
             </FluentButton>
         </TemplateColumn>
     </FluentDataGrid>
+
+    
 }
 
 @code {


### PR DESCRIPTION
Fixes #8

Add a button for creating a note on each line of the list of posts in the `Posts.razor` file.

* Update the `FluentDataGrid` to include a new column with the button.
* Add the `CreateNoteForPost` method to handle the button click event and navigate to the `Note` page with the `postID` as a parameter.
* Use a FluentUI Blazor Icon to represent a note instead of the text "Create Note".

Modify the `Note.razor` file to accept the `postID` as a parameter.

* Update the `@page` directive to include the `postId` parameter.
* Add a confirmation message after a user creates a note.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FBoucher/NoteBookmark/issues/8?shareId=c37bbc6d-58f8-4cdd-8c71-9eb866a04a50).