### PR TITLE
Add delete post functionality

### DIFF
--- a/NoteBookmark.Api/DataStorageService.cs
+++ b/NoteBookmark.Api/DataStorageService.cs
@@ -160,7 +160,17 @@ public class DataStorageService(string connectionString): IDataStorageService
         return true;
     }
 
-
+    public bool DeletePost(string rowKey)
+    {
+        var tblPost = GetPostTable();
+        var existingPost = tblPost.Query<Post>(filter: $"RowKey eq '{rowKey}'").FirstOrDefault();
+        if (existingPost != null)
+        {
+            tblPost.DeleteEntity(existingPost.PartitionKey, existingPost.RowKey);
+            return true;
+        }
+        return false;
+    }
 
     public List<Summary> GetSummaries()
     {

--- a/NoteBookmark.Api/IDataStorageService.cs
+++ b/NoteBookmark.Api/IDataStorageService.cs
@@ -31,4 +31,5 @@ public interface IDataStorageService
 
 	public Task UpdatePostReadStatus();
 
+    public bool DeletePost(string rowKey);
 }

--- a/NoteBookmark.Api/PostEndpoints.cs
+++ b/NoteBookmark.Api/PostEndpoints.cs
@@ -21,6 +21,8 @@ public static class PostEndpoints
 			.WithDescription("Save or Create a post");
 		endpoints.MapPost("/extractPostDetails", ExtractPostDetails)
 			.WithDescription("Extract post details from URL and save the post");
+		endpoints.MapDelete("/{id}", DeletePost)
+			.WithDescription("Delete a post by id");
 	}
 	
 	static List<PostL> GetUnreadPosts(IDataStorageService dataStorageService)
@@ -62,6 +64,14 @@ public static class PostEndpoints
 		}
 	}
 
+	static Results<Ok, NotFound> DeletePost(string id, IDataStorageService dataStorageService)
+	{
+		if (dataStorageService.DeletePost(id))
+		{
+			return TypedResults.Ok();
+		}
+		return TypedResults.NotFound();
+	}
 
 	private static async Task<Post?> ExtractPostDetailsFromUrl(string url)
     {

--- a/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
+++ b/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
@@ -30,14 +30,16 @@
             {
                 <FluentButton IconEnd="@(new Icons.Filled.Size24.NoteEdit())" />
             }
-            <FluentButton OnClick="@(async () => await DeletePost(context!.RowKey))" IconEnd="@(new Icons.Regular.Size24.Delete())" />
         </TemplateColumn>
         <PropertyColumn Title="Title" Property="@(c => c!.Title)" Sortable="true"/>
         <PropertyColumn Title="Published" 
                         Property="@(c => (c!.Date_published ?? "0000-00-00").Substring(0,10))"  
                         Sortable="true" SortBy="@defSort" 
                         IsDefaultSortColumn="true" 
-                        Width="130px"/>
+                        Width="125px"/>
+        <TemplateColumn Width="60px">   
+            <FluentButton OnClick="@(async () => await DeletePost(context!.RowKey))" IconEnd="@(new Icons.Regular.Size24.Delete())" />
+        </TemplateColumn>
     </ChildContent>
     <EmptyContent>
         <FluentIcon Value="@(new Icons.Filled.Size24.Crown())" Color="@Color.Accent" />&nbsp; Nothing to see here. Carry on!

--- a/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
+++ b/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
@@ -30,6 +30,7 @@
             {
                 <FluentButton IconEnd="@(new Icons.Filled.Size24.NoteEdit())" />
             }
+            <FluentButton OnClick="@(async () => await DeletePost(context!.RowKey))" IconEnd="@(new Icons.Regular.Size24.Delete())" />
         </TemplateColumn>
         <PropertyColumn Title="Title" Property="@(c => c!.Title)" Sortable="true"/>
         <PropertyColumn Title="Published" 
@@ -110,6 +111,20 @@
             {
                 toastService.ShowError("Failed to add post. Please try again.");
             }
+        }
+    }
+
+    private async Task DeletePost(string postId)
+    {
+        var result = await client.DeletePost(postId);
+        if (result)
+        {
+            await LoadPosts();
+            toastService.ShowSuccess("Post deleted successfully!");
+        }
+        else
+        {
+            toastService.ShowError("Failed to delete post. Please try again.");
         }
     }
 }

--- a/NoteBookmark.BlazorApp/Components/Pages/SummaryEditor.razor
+++ b/NoteBookmark.BlazorApp/Components/Pages/SummaryEditor.razor
@@ -164,7 +164,7 @@ else{
         }
         if(tab.Id == "tabHTML")
         {
-            readingNotesHTML = Markdown.ToHtml(readingNotesMD);
+            readingNotesHTML = Markdown.ToHtml(readingNotesMD!);
         }
         changedto = tab;
     }

--- a/NoteBookmark.BlazorApp/PostNoteClient.cs
+++ b/NoteBookmark.BlazorApp/PostNoteClient.cs
@@ -138,4 +138,10 @@ public class PostNoteClient(HttpClient httpClient)
         var response = await httpClient.PostAsJsonAsync($"api/posts/extractPostDetails?url={encodedUrl}", url);
         return response.IsSuccessStatusCode;
     }
+
+    public async Task<bool> DeletePost(string id)
+    {
+        var response = await httpClient.DeleteAsync($"api/posts/{id}");
+        return response.IsSuccessStatusCode;
+    }
 }


### PR DESCRIPTION
Fixes #42

Add functionality to delete a post on the posts page.

* Add `DeletePost` method to `NoteBookmark.Api/DataStorageService.cs` to delete a post by `RowKey`.
* Update `NoteBookmark.Api/IDataStorageService.cs` to include the `DeletePost` method.
* Add `Delete` endpoint to `NoteBookmark.Api/PostEndpoints.cs` to handle post deletion.
* Add delete button to each post row in `NoteBookmark.BlazorApp/Components/Pages/Posts.razor`.
* Add `DeletePost` method in `NoteBookmark.BlazorApp/Components/Pages/Posts.razor` to call the API to delete a post.

