### PR TITLE
See or hide read post from - 
Updates package versions and removes read posts endpoint


### DIFF
--- a/NoteBookmark.Api/PostEndpoints.cs
+++ b/NoteBookmark.Api/PostEndpoints.cs
@@ -17,6 +17,8 @@ public static class PostEndpoints
 
 		endpoints.MapGet("/", GetUnreadPosts)
 			.WithDescription("Get all unread posts");
+		endpoints.MapGet("/read", GetReadPosts)
+			.WithDescription("Get all read posts");
 		endpoints.MapGet("/{id}", Get)
 			.WithDescription("Get a post by id");
 		endpoints.MapPost("/", SavePost)
@@ -31,6 +33,12 @@ public static class PostEndpoints
 	{
 		var dataStorageService = new DataStorageService(tblClient, blobClient);
 		return dataStorageService.GetFilteredPosts("is_read eq false");
+	}
+
+	static List<PostL> GetReadPosts(TableServiceClient tblClient, BlobServiceClient blobClient)
+	{
+		var dataStorageService = new DataStorageService(tblClient, blobClient);
+		return dataStorageService.GetFilteredPosts("is_read eq true");
 	}
 
 	static Results<Ok<Post>, NotFound> Get(string id, TableServiceClient tblClient, BlobServiceClient blobClient)

--- a/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
+++ b/NoteBookmark.BlazorApp/Components/Pages/Posts.razor
@@ -1,6 +1,7 @@
 @page "/posts"
 @using NoteBookmark.BlazorApp.Components.Shared
 @using NoteBookmark.Domain
+@using Microsoft.FluentUI.AspNetCore.Components
 @inject PostNoteClient client
 @inject IJSRuntime jsRuntime
 @inject IToastService toastService
@@ -12,23 +13,29 @@
 
 <h1>Posts</h1>
 
-<FluentStack Orientation="Orientation.Horizontal">
-    <FluentButton OnClick="AddNewPost" IconEnd="@(new Icons.Regular.Size24.Add())" Title="Add new post"></FluentButton>
-    <FluentTextField @bind-Value="newPostUrl" Placeholder="Enter URL" style="width: 100%;"/>
+<FluentStack Orientation="Orientation.Vertical">
+    <FluentStack Orientation="Orientation.Horizontal">
+        <FluentButton OnClick="AddNewPost" IconEnd="@(new Icons.Regular.Size20.Add())" Title="Add new post"></FluentButton>
+        <FluentTextField @bind-Value="newPostUrl" Placeholder="Enter URL" style="width: 100%;"/>
+    </FluentStack>
+    <FluentSwitch ValueChanged="OnShowReadChanged" Label="Show">
+        <span slot="checked-message">Read Only</span>
+        <span slot="unchecked-message">UnRead Only</span>
+    </FluentSwitch>
 </FluentStack>
 
 <FluentDataGrid Id="postgrid" Items="@posts">
     <ChildContent>       
         <TemplateColumn Width="150px">
-            <FluentButton OnClick="@(async () => await OpenUrlInNewWindow(context!.Url))" IconEnd="@(new Icons.Regular.Size24.Open())" />
-            <FluentButton OnClick="@(() => EditNote(context!.RowKey))" IconEnd="@(new Icons.Regular.Size24.Edit())" />
+            <FluentButton OnClick="@(async () => await OpenUrlInNewWindow(context!.Url))" IconEnd="@(new Icons.Regular.Size20.Open())" />
+            <FluentButton OnClick="@(() => EditNote(context!.RowKey))" IconEnd="@(new Icons.Regular.Size20.Edit())" />
             @if (String.IsNullOrEmpty(context!.NoteId))
             {
-                <FluentButton OnClick="@(async () => await CreateNoteForPost(context!.RowKey))"  IconEnd="@(new Icons.Regular.Size24.NoteAdd())" />
+                <FluentButton OnClick="@(async () => await CreateNoteForPost(context!.RowKey))"  IconEnd="@(new Icons.Regular.Size20.NoteAdd())" />
             }
             else
             {
-                <FluentButton IconEnd="@(new Icons.Filled.Size24.NoteEdit())" />
+                <FluentButton IconEnd="@(new Icons.Filled.Size20.NoteEdit())" />
             }
         </TemplateColumn>
         <PropertyColumn Title="Title" Property="@(c => c!.Title)" Sortable="true"/>
@@ -38,11 +45,11 @@
                         IsDefaultSortColumn="true" 
                         Width="125px"/>
         <TemplateColumn Width="60px">   
-            <FluentButton OnClick="@(async () => await DeletePost(context!.RowKey))" IconEnd="@(new Icons.Regular.Size24.Delete())" />
+            <FluentButton OnClick="@(async () => await DeletePost(context!.RowKey))" IconEnd="@(new Icons.Regular.Size20.Delete())" />
         </TemplateColumn>
     </ChildContent>
     <EmptyContent>
-        <FluentIcon Value="@(new Icons.Filled.Size24.Crown())" Color="@Color.Accent" />&nbsp; Nothing to see here. Carry on!
+        <FluentIcon Value="@(new Icons.Filled.Size20.Crown())" Color="@Color.Accent" />&nbsp; Nothing to see here. Carry on!
     </EmptyContent>
 </FluentDataGrid>
 
@@ -51,6 +58,7 @@
     private IQueryable<PostL>? posts;
     private GridSort<PostL> defSort = GridSort<PostL>.ByDescending(c => c.Date_published);
     private string newPostUrl = string.Empty;
+    private bool showRead = false;
 
     protected override async Task OnInitializedAsync()
     {
@@ -59,8 +67,8 @@
 
     private async Task LoadPosts()
     {
-        List<PostL> urPosts = await client.GetUnreadPosts();
-        posts = urPosts.AsQueryable();
+        List<PostL> loadedPosts = showRead ? await client.GetReadPosts(): await client.GetUnreadPosts();
+        posts = loadedPosts.AsQueryable();
     }
 
     private async Task OpenUrlInNewWindow(string? url)
@@ -129,5 +137,12 @@
         {
             toastService.ShowError("Failed to delete post. Please try again.");
         }
+    }
+
+    // Add handler to reload posts when toggle changes
+    private async Task OnShowReadChanged(bool value)
+    {
+        showRead = value;
+        await LoadPosts();
     }
 }

--- a/NoteBookmark.BlazorApp/PostNoteClient.cs
+++ b/NoteBookmark.BlazorApp/PostNoteClient.cs
@@ -11,6 +11,12 @@ public class PostNoteClient(HttpClient httpClient)
         return posts ?? new List<PostL>();
     }
 
+    public async Task<List<PostL>> GetReadPosts()
+    {
+        var posts = await httpClient.GetFromJsonAsync<List<PostL>>("api/posts/read");
+        return posts ?? new List<PostL>();
+    }
+
     public async Task<List<Summary>> GetSummaries()
     {
         var summaries = await httpClient.GetFromJsonAsync<List<Summary>>("api/summary");


### PR DESCRIPTION

Updates various package versions to align with project requirements and address potential compatibility issues.

Removes the dedicated endpoint for retrieving read posts, streamlining the API and simplifying data retrieval logic. The filtering of read posts can be handled on the client side or through other existing endpoints.
