### PR TITLE
quickfix: refact Research service rollback to raw httpclient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -513,3 +513,5 @@ todos/
 .github/agents/
 # Squad (local AI team - not committed)
 .ai-team/
+
+src/NoteBookmark.BlazorApp/Data/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.1.1-preview.1.25612.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="System.Text.Json" Version="9.0.10" />
+    <PackageVersion Include="Reka.SDK" Version="0.1.0" />
     <!-- Test packages -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />

--- a/src/NoteBookmark.AIServices.Tests/ResearchServiceTests.cs
+++ b/src/NoteBookmark.AIServices.Tests/ResearchServiceTests.cs
@@ -7,6 +7,7 @@ namespace NoteBookmark.AIServices.Tests;
 public class ResearchServiceTests
 {
     private readonly Mock<ILogger<ResearchService>> _mockLogger;
+    private readonly HttpClient _httpClient = new();
 
     public ResearchServiceTests()
     {
@@ -18,7 +19,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: null);
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt") { SearchTopic = "AI" };
 
         // Act
@@ -35,7 +36,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: null);
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act
@@ -50,7 +51,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: "test-api-key-from-settings");
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt") { SearchTopic = "Testing" };
 
         // Act - Will fail to connect but won't throw missing config exception
@@ -65,7 +66,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: "test-reka-key");
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt") { SearchTopic = "Testing" };
 
         // Act
@@ -81,7 +82,7 @@ public class ResearchServiceTests
         // Arrange
         const string customUrl = "https://custom.api.example.com/v1";
         var settingsProvider = CreateSettingsProvider(apiKey: "test-key", baseUrl: customUrl);
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act
@@ -96,7 +97,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: "test-key", baseUrl: "https://api.reka.ai/v1");
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act
@@ -112,7 +113,7 @@ public class ResearchServiceTests
         // Arrange
         const string customModel = "custom-model-v2";
         var settingsProvider = CreateSettingsProvider(apiKey: "test-key", modelName: customModel);
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act
@@ -127,7 +128,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: "test-key", modelName: "reka-flash-research");
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act
@@ -142,7 +143,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: "test-key", baseUrl: "not-a-valid-url");
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act
@@ -159,7 +160,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: "test-key");
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act
@@ -175,7 +176,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: "test-key");
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Find articles about {topic}")
         {
             SearchTopic = "Machine Learning",
@@ -199,7 +200,7 @@ public class ResearchServiceTests
     {
         // Arrange
         var settingsProvider = CreateSettingsProvider(apiKey: emptyKey);
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act
@@ -216,7 +217,7 @@ public class ResearchServiceTests
     {
         // Arrange - Both AppSettings and env var set, AppSettings should take precedence
         var settingsProvider = CreateSettingsProvider(apiKey: "settings-key");
-        var service = new ResearchService(_mockLogger.Object, settingsProvider);
+        var service = new ResearchService(_httpClient, _mockLogger.Object, settingsProvider);
         var searchCriterias = new SearchCriterias("Test prompt");
 
         // Act

--- a/src/NoteBookmark.AIServices/NoteBookmark.AIServices.csproj
+++ b/src/NoteBookmark.AIServices/NoteBookmark.AIServices.csproj
@@ -5,6 +5,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging" />
       <PackageReference Include="Microsoft.Agents.AI" />
       <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+      <PackageReference Include="Reka.SDK" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NoteBookmark.AIServices/ResearchService.cs
+++ b/src/NoteBookmark.AIServices/ResearchService.cs
@@ -7,6 +7,8 @@ using Microsoft.Agents.AI;
 using OpenAI;
 using OpenAI.Chat;
 using NoteBookmark.Domain;
+using Reka.SDK;
+using System.Text;
 
 namespace NoteBookmark.AIServices;
 
@@ -14,12 +16,15 @@ public class ResearchService
 {
     private readonly ILogger<ResearchService> _logger;
     private readonly Func<Task<(string ApiKey, string BaseUrl, string ModelName)>> _settingsProvider;
+    private readonly HttpClient _client;
 
     public ResearchService(
+        HttpClient client,
         ILogger<ResearchService> logger, 
         Func<Task<(string ApiKey, string BaseUrl, string ModelName)>> settingsProvider)
     {
         _logger = logger;
+        _client = client;
         _settingsProvider = settingsProvider;
     }
 
@@ -27,43 +32,75 @@ public class ResearchService
     {
         PostSuggestions suggestions = new PostSuggestions();
 
+        HttpResponseMessage? response = null;
+
         try
         {
             var settings = await _settingsProvider();
 
-            IChatClient chatClient = new ChatClient(
-                settings.ModelName,
-                new ApiKeyCredential(settings.ApiKey),
-                new OpenAIClientOptions { Endpoint = new Uri(settings.BaseUrl) }
-            ).AsIChatClient();
-
-            var jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            var webSearch = new Dictionary<string, object>
             {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
-            };
-            
-            JsonElement schema = AIJsonUtilities.CreateJsonSchema(typeof(PostSuggestions), serializerOptions: jsonOptions);
-
-            ChatOptions chatOptions = new()
-            {
-                ResponseFormat = Microsoft.Extensions.AI.ChatResponseFormat.ForJsonSchema(
-                    schema: schema,
-                    schemaName: "PostSuggestions",
-                    schemaDescription: "A list of suggested posts with title, author, summary, publication date, and URL")
+                ["max_uses"] = 3
             };
 
-            AIAgent agent = new ChatClientAgent(chatClient, new ChatClientAgentOptions
+            var allowedDomains = searchCriterias.GetSplittedAllowedDomains();
+            var blockedDomains = searchCriterias.GetSplittedBlockedDomains();
+
+            if (allowedDomains != null && allowedDomains.Length > 0)
             {
-                Name = "ResearchAgent",
-                ChatOptions = chatOptions
+                webSearch["allowed_domains"] = allowedDomains;
+            }
+            else if (blockedDomains != null && blockedDomains.Length > 0)
+            {
+                webSearch["blocked_domains"] = blockedDomains;
+            }
+
+            var requestPayload = new
+            {
+                model = settings.ModelName,
+
+                messages = new[]
+                {
+                    new
+                    {
+                        role = "user",
+                        content = searchCriterias.GetSearchPrompt()
+                    }
+                },
+                response_format = GetResponseFormat(),
+                research = new
+                {
+                    web_search = webSearch
+                },
+            };
+
+            var jsonPayload = JsonSerializer.Serialize(requestPayload, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             });
 
-            var prompt = searchCriterias.GetSearchPrompt();
-            var response = await agent.RunAsync(prompt);
-            
-            suggestions = response.Deserialize<PostSuggestions>(jsonOptions) ?? new PostSuggestions();
-            
-            await SaveToFile("research_response", response.ToString() ?? string.Empty);
+            // await SaveToFile("research_request", jsonPayload);
+
+            var endpoint = settings.BaseUrl.TrimEnd('/') + "/chat/completions";
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+            request.Headers.Add("Authorization", $"Bearer {settings.ApiKey}");
+            request.Content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+    
+            response = await _client.SendAsync(request);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            await SaveToFile("research_response", responseContent);
+    
+            var rekaResponse = JsonSerializer.Deserialize<RekaResponse>(responseContent);
+    
+            if (response.IsSuccessStatusCode)
+            {
+                suggestions = JsonSerializer.Deserialize<PostSuggestions>(rekaResponse!.Choices![0].Message!.Content!)!;
+            }
+            else
+            {
+                throw new Exception($"Request failed with status code: {response.StatusCode}. Response: {responseContent}");
+            }
         }
         catch (Exception ex)
         {
@@ -71,6 +108,43 @@ public class ResearchService
         }
 
         return suggestions;
+    }
+
+    private object GetResponseFormat()
+    {
+        return new
+        {
+            type = "json_schema",
+            json_schema = new
+            {
+                name = "post_suggestions",
+                schema = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        suggestions = new
+                        {
+                            type = "array",
+                            items = new
+                            {
+                                type = "object",
+                                properties = new
+                                {
+                                    title = new { type = "string" },
+                                    author = new { type = "string" },
+                                    summary = new { type = "string", maxLength = 100 },
+                                    publication_date = new { type = "string", format = "date" },
+                                    url = new { type = "string" }
+                                },
+                                required = new[] { "title", "summary", "url" }
+                            }
+                        }
+                    },
+                    required = new[] { "post_suggestions" }
+                }
+            }
+        };
     }
 
     private async Task SaveToFile(string prefix, string responseContent)

--- a/src/NoteBookmark.BlazorApp/Program.cs
+++ b/src/NoteBookmark.BlazorApp/Program.cs
@@ -40,11 +40,15 @@ builder.Services.AddTransient<SummaryService>(sp =>
     return new SummaryService(logger, provider);
 });
 
+builder.Services.AddHttpClient(nameof(ResearchService));
+
 builder.Services.AddTransient<ResearchService>(sp =>
 {
     var logger = sp.GetRequiredService<ILogger<ResearchService>>();
     var settingsProvider = sp.GetRequiredService<AISettingsProvider>();
-    
+    var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+    var client = httpClientFactory.CreateClient(nameof(ResearchService));
+
     // Settings provider that fetches directly from database (server-side, unmasked)
     Func<Task<(string ApiKey, string BaseUrl, string ModelName)>> provider = async () =>
     {
@@ -55,8 +59,8 @@ builder.Services.AddTransient<ResearchService>(sp =>
             settings.ModelName
         );
     };
-    
-    return new ResearchService(logger, provider);
+
+    return new ResearchService(client, logger, provider);
 });
 
 


### PR DESCRIPTION
rollback to raw httpclient to keep the domains features

This change includes:
- Addition of Reka.SDK package.
- Updates the ResearchService to use Reka's API for search.
- Configures the DI in the blazor app to use the http client.
- Adds .gitignore entry to ignore the Data folder.

The motivation is to leverage Reka's AI models for improved research capabilities within the NoteBookmark application.
