### PR TITLE
fix: deduplicate summary tags (#111)

### DIFF
--- a/src/NoteBookmark.Api.Tests/Domain/ReadingNotesTests.cs
+++ b/src/NoteBookmark.Api.Tests/Domain/ReadingNotesTests.cs
@@ -61,8 +61,8 @@ public class ReadingNotesTests
     {
         // Arrange
         var readingNotes = new ReadingNotes("100");
-        var note1 = new ReadingNote { Tags = "azure.functions.serverless" };
-        var note2 = new ReadingNote { Tags = "azure.storage.blob" };
+        var note1 = new ReadingNote { Tags = "azure, functions, serverless" };
+        var note2 = new ReadingNote { Tags = "azure, storage, blob" };
 
         readingNotes.Notes["Technology"] = new List<ReadingNote> { note1, note2 };
 
@@ -76,5 +76,31 @@ public class ReadingNotesTests
         uniqueTags.Should().Contain("storage");
         uniqueTags.Should().Contain("blob");
         uniqueTags.Should().Contain("readingnotes");
+    }
+
+    [Fact]
+    public void ReadingNotes_GetAllUniqueTags_DeduplicatesTagsSharedAcrossNotes()
+    {
+        // Arrange - mirrors the real-world bug: multiple notes share a leading tag (e.g. "ai")
+        var readingNotes = new ReadingNotes("690");
+        var note1 = new ReadingNote { Tags = "ai, agent, skill" };
+        var note2 = new ReadingNote { Tags = "ai, dev, best practices" };
+        var note3 = new ReadingNote { Tags = "ai, mcp, debug" };
+
+        readingNotes.Notes["AI"] = new List<ReadingNote> { note1, note2, note3 };
+
+        // Act
+        var uniqueTags = readingNotes.GetAllUniqueTags();
+        var tagList = uniqueTags.Split(',').Select(t => t.Trim()).ToList();
+
+        // Assert - "ai" must appear exactly once despite being in 3 notes
+        tagList.Count(t => t == "ai").Should().Be(1);
+        tagList.Should().Contain("agent");
+        tagList.Should().Contain("skill");
+        tagList.Should().Contain("dev");
+        tagList.Should().Contain("best practices");
+        tagList.Should().Contain("mcp");
+        tagList.Should().Contain("debug");
+        tagList.Should().Contain("readingnotes");
     }
 }

--- a/src/NoteBookmark.Domain/ReadingNote.cs
+++ b/src/NoteBookmark.Domain/ReadingNote.cs
@@ -28,18 +28,17 @@ public class ReadingNote
 
     public string? RowKey { get; set; }
 
-    private string GetCategory()
-    {
-        string category = "misc";
-        if (!string.IsNullOrEmpty(Tags))
-        {
-            var newListTags = Tags.Split('.');
-
-            category = newListTags[0];
-        }
-
-        return NoteCategories.GetCategory(category);
-    }
+    // TODO: dead code — Category is set directly via the NoteDialog UI and this method is never called. Remove when confirmed safe.
+    // private string GetCategory()
+    // {
+    //     string category = "misc";
+    //     if (!string.IsNullOrEmpty(Tags))
+    //     {
+    //         var newListTags = Tags.Split('.');
+    //         category = newListTags[0];
+    //     }
+    //     return NoteCategories.GetCategory(category);
+    // }
 
     public string? ToMarkDown()
     {

--- a/src/NoteBookmark.Domain/ReadingNotes.cs
+++ b/src/NoteBookmark.Domain/ReadingNotes.cs
@@ -48,7 +48,7 @@ public class ReadingNotes
             {
                 if (!string.IsNullOrEmpty(note.Tags))
                 {
-                    var tags = note.Tags.ToLower().Split('.');
+                    var tags = note.Tags.ToLower().Split(',').Select(t => t.Trim()).Where(t => !string.IsNullOrEmpty(t));
                     uniqueTags = uniqueTags.Concat(tags).ToHashSet();
                 }
             }


### PR DESCRIPTION
## Summary

- `GetAllUniqueTags()` was splitting tags on `.` (period) but tags are stored as comma-separated strings (e.g. `"ai, agent, skill"`), so each full tag string was added to the HashSet unsplit — causing repeated tags like `ai` to appear multiple times in the output
- Fixed by splitting on `,` and trimming whitespace
- Commented out dead `GetCategory()` method in `ReadingNote` (never called — category is set directly via the UI)
- Updated existing test that used the wrong `.` separator, and added a regression test matching the exact duplication scenario from the bug report

## Test plan

- [ ] Run `dotnet test` on `NoteBookmark.Api.Tests` — all `ReadingNotes` domain tests pass
- [ ] Open a summary with multiple notes sharing a common tag (e.g. `ai`) and verify each tag appears only once

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)