### PR TITLE
ci: block .squad/.copilot files from merging into main (#116)

### DIFF
--- a/.github/workflows/block-squad-on-main.yml
+++ b/.github/workflows/block-squad-on-main.yml
@@ -1,0 +1,32 @@
+name: Block AI team files on main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-ai-files:
+    name: No .squad / .copilot files on main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail if PR adds AI team files to main
+        run: |
+          # --diff-filter=AM: only Added or Modified — deletions (cleanup PRs) are allowed
+          FILES=$(git diff --name-only --diff-filter=AM origin/main...HEAD \
+            | grep -E "^\.squad/|^\.copilot/|^\.github/agents/" || true)
+
+          if [ -n "$FILES" ]; then
+            echo "❌ This PR adds AI team files to main."
+            echo "   .squad/, .copilot/, and .github/agents/ belong on dev branches only."
+            echo ""
+            echo "Offending files:"
+            echo "$FILES"
+            exit 1
+          fi
+
+          echo "✅ No AI team files detected in this PR."


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that fails any PR to `main` that adds or modifies files under `.squad/`, `.copilot/`, or `.github/agents/`.

## Why

Closes #116 — AI team files should live on dev/feature branches only.

## Notes

- Uses `--diff-filter=AM` so **deletions are allowed** (the cleanup PR won't be blocked)
- Triggers only on PRs targeting `main`