### PR TITLE
feat: DateModified + delta API endpoints (#121)

### DIFF
--- a/.squad/agents/biggs/history.md
+++ b/.squad/agents/biggs/history.md
@@ -74,3 +74,37 @@ Biggs' regression testing confirmed zero behavioral changes from Leia's componen
 **Cross-agent note:** Identified component-level refactoring needed in NoteDialog: replace `Dialog.CloseAsync()` with `EventCallback<NoteDialogResult>` to eliminate cascade dependency and enable full test coverage. Recommending this for future dev cycle.
 
 Ready for Wedge to scaffold MAUI app (#120).
+
+---
+
+## Issue #121 — Proactive Delta API Integration Tests (2026-04-03)
+
+**Branch:** `squad/121-date-modified-delta-api` (created from v-next, Han picks this up)  
+**File:** `src/NoteBookmark.Api.Tests/Integration/DeltaApiTests.cs`  
+**Status:** ✅ COMMITTED — tests compile, intentionally RED until Han ships
+
+### What was written
+8 integration tests covering `modifiedAfter` query param for both list endpoints:
+
+**Posts (GET /api/posts/?modifiedAfter=):**
+1. `GetPosts_WithModifiedAfter_ReturnsOnlyRecentPosts`
+2. `GetPosts_WithModifiedAfter_FutureTimestamp_ReturnsEmpty`
+3. `GetPosts_WithoutModifiedAfter_ReturnsAllPosts` (non-breaking baseline)
+4. `GetPosts_WithModifiedAfter_MultipleResults`
+
+**Notes (GET /api/notes/?modifiedAfter=):**
+Same 4 patterns mirrored for notes.
+
+### Patterns used
+
+**Timing-based seeding:** Since `DateModified` doesn't exist on `Post` / `Note` domain models yet, tests use `Task.Delay(150ms)` + `DateTime.UtcNow` threshold to separate "old" from "new" entities created via HTTP POST. Han's implementation will set `DateModified` server-side on create, making the filter effective.
+
+**RowKey-presence assertions:** Rather than asserting total list counts (fragile under shared Azurite state), tests assert that specific entities (by RowKey) are present or absent. This survives data leakage between test methods sharing the same `IClassFixture<NoteBookmarkApiTestFactory>` instance.
+
+**Non-breaking baseline test:** `GetPosts_WithoutModifiedAfter_ReturnsAllPosts` documents that omitting the new param must not change existing behaviour — a regression guard for Han.
+
+### Discoveries
+- `PostL` (the response DTO returned by GET /api/posts/) **already has `DateModified`** defined in the domain model — Han only needs to populate it and wire the filter.
+- `Note` does NOT yet have `DateModified` — Han must add it alongside the filter.
+- `NoteEnpoints.cs` has a typo in the filename (missing 'd') — pre-existing, not touched.
+- Build: ✅ 0 errors, 8 pre-existing warnings (unchanged).

--- a/src/NoteBookmark.Api.Tests/Endpoints/DeltaApiTests.cs
+++ b/src/NoteBookmark.Api.Tests/Endpoints/DeltaApiTests.cs
@@ -1,0 +1,320 @@
+using FluentAssertions;
+using NoteBookmark.Api.Tests.Fixtures;
+using NoteBookmark.Domain;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace NoteBookmark.Api.Tests.Endpoints;
+
+public class DeltaApiTests : IClassFixture<NoteBookmarkApiTestFactory>
+{
+    private readonly NoteBookmarkApiTestFactory _factory;
+    private readonly HttpClient _client;
+
+    public DeltaApiTests(NoteBookmarkApiTestFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+    }
+
+    // ── Posts modifiedAfter ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetUnreadPosts_WithModifiedAfter_ReturnsOnlyNewerPosts()
+    {
+        // Arrange
+        var oldPost = CreateTestPost("delta-old-post-1");
+        var newPost = CreateTestPost("delta-new-post-1");
+
+        await _client.PostAsJsonAsync("/api/posts/", oldPost);
+        await Task.Delay(50);
+        var threshold = DateTime.UtcNow;
+        await Task.Delay(50);
+        await _client.PostAsJsonAsync("/api/posts/", newPost);
+
+        // Act
+        var response = await _client.GetAsync($"/api/posts/?modifiedAfter={threshold:O}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var posts = await response.Content.ReadFromJsonAsync<List<PostL>>();
+        posts.Should().NotBeNull();
+        posts.Should().Contain(p => p.RowKey == newPost.RowKey);
+        posts.Should().NotContain(p => p.RowKey == oldPost.RowKey);
+    }
+
+    [Fact]
+    public async Task GetUnreadPosts_WithoutModifiedAfter_ReturnsAllUnreadPosts()
+    {
+        // Arrange
+        var post1 = CreateTestPost("delta-all-posts-1");
+        var post2 = CreateTestPost("delta-all-posts-2");
+        await _client.PostAsJsonAsync("/api/posts/", post1);
+        await _client.PostAsJsonAsync("/api/posts/", post2);
+
+        // Act
+        var response = await _client.GetAsync("/api/posts/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var posts = await response.Content.ReadFromJsonAsync<List<PostL>>();
+        posts.Should().NotBeNull();
+        posts.Should().Contain(p => p.RowKey == post1.RowKey);
+        posts.Should().Contain(p => p.RowKey == post2.RowKey);
+    }
+
+    [Fact]
+    public async Task GetUnreadPosts_WithFutureModifiedAfter_ReturnsEmptyList()
+    {
+        // Arrange
+        var post = CreateTestPost("delta-empty-posts-1");
+        await _client.PostAsJsonAsync("/api/posts/", post);
+        var futureTimestamp = DateTime.UtcNow.AddHours(1);
+
+        // Act
+        var response = await _client.GetAsync($"/api/posts/?modifiedAfter={futureTimestamp:O}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var posts = await response.Content.ReadFromJsonAsync<List<PostL>>();
+        posts.Should().NotBeNull();
+        posts.Should().NotContain(p => p.RowKey == post.RowKey);
+    }
+
+    [Fact]
+    public async Task GetUnreadPosts_WithModifiedAfter_MultipleResults()
+    {
+        // Arrange
+        var oldPost = CreateTestPost("delta-multi-old-1");
+        await _client.PostAsJsonAsync("/api/posts/", oldPost);
+        await Task.Delay(50);
+        var threshold = DateTime.UtcNow;
+        await Task.Delay(50);
+
+        var newPost1 = CreateTestPost("delta-multi-new-1");
+        var newPost2 = CreateTestPost("delta-multi-new-2");
+        await _client.PostAsJsonAsync("/api/posts/", newPost1);
+        await _client.PostAsJsonAsync("/api/posts/", newPost2);
+
+        // Act
+        var response = await _client.GetAsync($"/api/posts/?modifiedAfter={threshold:O}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var posts = await response.Content.ReadFromJsonAsync<List<PostL>>();
+        posts.Should().NotBeNull();
+        posts.Should().Contain(p => p.RowKey == newPost1.RowKey);
+        posts.Should().Contain(p => p.RowKey == newPost2.RowKey);
+        posts.Should().NotContain(p => p.RowKey == oldPost.RowKey);
+    }
+
+    // ── Notes modifiedAfter ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetNotes_WithModifiedAfter_ReturnsOnlyNewerNotes()
+    {
+        // Arrange
+        var testPost = await CreateAndSaveTestPost("delta-note-post-1");
+        var oldNote = CreateTestNote("delta-old-note-1", testPost.RowKey);
+        await _client.PostAsJsonAsync("/api/notes/note", oldNote);
+        await Task.Delay(50);
+        var threshold = DateTime.UtcNow;
+        await Task.Delay(50);
+        var newNote = CreateTestNote("delta-new-note-1", testPost.RowKey);
+        await _client.PostAsJsonAsync("/api/notes/note", newNote);
+
+        // Act
+        var response = await _client.GetAsync($"/api/notes/?modifiedAfter={threshold:O}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        notes.Should().NotBeNull();
+        notes.Should().Contain(n => n.RowKey == newNote.RowKey);
+        notes.Should().NotContain(n => n.RowKey == oldNote.RowKey);
+    }
+
+    [Fact]
+    public async Task GetNotes_WithoutModifiedAfter_ReturnsAllNotes()
+    {
+        // Arrange
+        var testPost = await CreateAndSaveTestPost("delta-all-notes-post-1");
+        var note1 = CreateTestNote("delta-all-notes-1", testPost.RowKey);
+        var note2 = CreateTestNote("delta-all-notes-2", testPost.RowKey);
+        await _client.PostAsJsonAsync("/api/notes/note", note1);
+        await _client.PostAsJsonAsync("/api/notes/note", note2);
+
+        // Act
+        var response = await _client.GetAsync("/api/notes/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        notes.Should().NotBeNull();
+        notes.Should().Contain(n => n.RowKey == note1.RowKey);
+        notes.Should().Contain(n => n.RowKey == note2.RowKey);
+    }
+
+    [Fact]
+    public async Task GetNotes_WithFutureModifiedAfter_ReturnsEmptyForOurNotes()
+    {
+        // Arrange
+        var testPost = await CreateAndSaveTestPost("delta-empty-notes-post-1");
+        var note = CreateTestNote("delta-empty-note-1", testPost.RowKey);
+        await _client.PostAsJsonAsync("/api/notes/note", note);
+        var futureTimestamp = DateTime.UtcNow.AddHours(1);
+
+        // Act
+        var response = await _client.GetAsync($"/api/notes/?modifiedAfter={futureTimestamp:O}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        notes.Should().NotBeNull();
+        notes.Should().NotContain(n => n.RowKey == note.RowKey);
+    }
+
+    [Fact]
+    public async Task GetNotes_WithModifiedAfter_MultipleResults()
+    {
+        // Arrange
+        var testPost = await CreateAndSaveTestPost("delta-multi-notes-post-1");
+        var oldNote = CreateTestNote("delta-multi-old-note-1", testPost.RowKey);
+        await _client.PostAsJsonAsync("/api/notes/note", oldNote);
+        await Task.Delay(50);
+        var threshold = DateTime.UtcNow;
+        await Task.Delay(50);
+
+        var newNote1 = CreateTestNote("delta-multi-new-note-1", testPost.RowKey);
+        var newNote2 = CreateTestNote("delta-multi-new-note-2", testPost.RowKey);
+        await _client.PostAsJsonAsync("/api/notes/note", newNote1);
+        await _client.PostAsJsonAsync("/api/notes/note", newNote2);
+
+        // Act
+        var response = await _client.GetAsync($"/api/notes/?modifiedAfter={threshold:O}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        notes.Should().NotBeNull();
+        notes.Should().Contain(n => n.RowKey == newNote1.RowKey);
+        notes.Should().Contain(n => n.RowKey == newNote2.RowKey);
+        notes.Should().NotContain(n => n.RowKey == oldNote.RowKey);
+    }
+
+    // ── PATCH Posts ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PatchPost_UpdatesDateModified()
+    {
+        // Arrange
+        var post = CreateTestPost("delta-patch-post-1");
+        await _client.PostAsJsonAsync("/api/posts/", post);
+        await Task.Delay(50);
+        var beforePatch = DateTime.UtcNow;
+        await Task.Delay(50);
+
+        var patch = CreateTestPost("delta-patch-post-1");
+        patch.Title = "Patched Title";
+
+        // Act
+        var response = await _client.PatchAsJsonAsync($"/api/posts/{post.RowKey}", patch);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<Post>();
+        updated.Should().NotBeNull();
+        updated!.DateModified.Should().BeAfter(beforePatch);
+    }
+
+    [Fact]
+    public async Task PatchPost_WithNonExistentId_ReturnsNotFound()
+    {
+        // Arrange
+        var patch = CreateTestPost("any-post");
+
+        // Act
+        var response = await _client.PatchAsJsonAsync("/api/posts/non-existent-post-id", patch);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── PATCH Notes ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PatchNote_UpdatesDateModified()
+    {
+        // Arrange
+        var testPost = await CreateAndSaveTestPost("delta-patch-note-post-1");
+        var note = CreateTestNote("delta-patch-note-1", testPost.RowKey);
+        await _client.PostAsJsonAsync("/api/notes/note", note);
+        await Task.Delay(50);
+        var beforePatch = DateTime.UtcNow;
+        await Task.Delay(50);
+
+        var patch = CreateTestNote("delta-patch-note-1", testPost.RowKey);
+        patch.Comment = "Patched comment";
+
+        // Act
+        var response = await _client.PatchAsJsonAsync($"/api/notes/note/{note.RowKey}", patch);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<Note>();
+        updated.Should().NotBeNull();
+        updated!.DateModified.Should().BeAfter(beforePatch);
+    }
+
+    [Fact]
+    public async Task PatchNote_WithNonExistentRowKey_ReturnsNotFound()
+    {
+        // Arrange
+        var patch = CreateTestNote("any-note", "any-post");
+
+        // Act
+        var response = await _client.PatchAsJsonAsync("/api/notes/note/non-existent-note-id", patch);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<Post> CreateAndSaveTestPost(string rowKey)
+    {
+        var post = CreateTestPost(rowKey);
+        var response = await _client.PostAsJsonAsync("/api/posts/", post);
+        response.EnsureSuccessStatusCode();
+        return post;
+    }
+
+    private static Post CreateTestPost(string rowKey)
+    {
+        return new Post
+        {
+            PartitionKey = "posts",
+            RowKey = rowKey,
+            Title = "Delta Test Post",
+            Url = "https://example.com/delta-test",
+            Author = "Delta Author",
+            Date_published = "2025-06-03",
+            is_read = false,
+            Id = rowKey
+        };
+    }
+
+    private static Note CreateTestNote(string rowKey, string postId)
+    {
+        return new Note
+        {
+            PartitionKey = "test-delta-notes",
+            RowKey = rowKey,
+            PostId = postId,
+            Comment = "Delta test comment",
+            Tags = "delta, test",
+            Category = "Technology"
+        };
+    }
+}

--- a/src/NoteBookmark.Api.Tests/Integration/DeltaApiTests.cs
+++ b/src/NoteBookmark.Api.Tests/Integration/DeltaApiTests.cs
@@ -1,0 +1,293 @@
+using NoteBookmark.Api.Tests.Fixtures;
+using NoteBookmark.Api.Tests.Helpers;
+using NoteBookmark.Domain;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace NoteBookmark.Api.Tests.Integration;
+
+/// <summary>
+/// Proactive integration tests for the delta API (modifiedAfter query parameter).
+/// Documents the expected contract from Issue #121.
+///
+/// ⚠️ These tests are INTENTIONALLY RED until Han's implementation lands:
+///   - DateModified field added to Post and Note domain models
+///   - modifiedAfter query parameter added to GET /api/posts/ and GET /api/notes/
+/// </summary>
+public class DeltaApiTests : IClassFixture<NoteBookmarkApiTestFactory>
+{
+    private readonly NoteBookmarkApiTestFactory _factory;
+    private readonly HttpClient _client;
+
+    public DeltaApiTests(NoteBookmarkApiTestFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Posts delta — GET /api/posts/?modifiedAfter={timestamp}
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPosts_WithModifiedAfter_ReturnsOnlyRecentPosts()
+    {
+        // Arrange: create an "old" post, record a threshold, then create a "new" post
+        var oldPost = TestDataBuilder.Post()
+            .WithTitle("Old Post — delta test A")
+            .WithUrl("https://example.com/delta-old-a")
+            .AsUnread()
+            .Build();
+        await _client.PostAsJsonAsync("/api/posts/", oldPost);
+
+        var threshold = DateTime.UtcNow;
+        await Task.Delay(150); // ensure the server clock advances past the threshold
+
+        var newPost = TestDataBuilder.Post()
+            .WithTitle("New Post — delta test A")
+            .WithUrl("https://example.com/delta-new-a")
+            .AsUnread()
+            .Build();
+        await _client.PostAsJsonAsync("/api/posts/", newPost);
+
+        // Act
+        var response = await _client.GetAsync(
+            $"/api/posts/?modifiedAfter={Uri.EscapeDataString(threshold.ToString("O"))}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var posts = await response.Content.ReadFromJsonAsync<List<PostL>>();
+        posts.Should().NotBeNull();
+        posts!.Should().Contain(p => p.RowKey == newPost.RowKey,
+            "the post created after the threshold should appear in the delta results");
+        posts!.Should().NotContain(p => p.RowKey == oldPost.RowKey,
+            "the post created before the threshold should be excluded from delta results");
+    }
+
+    [Fact]
+    public async Task GetPosts_WithModifiedAfter_FutureTimestamp_ReturnsEmpty()
+    {
+        // Arrange: create a post that pre-dates a future threshold
+        var post = TestDataBuilder.Post()
+            .WithTitle("Post — delta future test")
+            .WithUrl("https://example.com/delta-future-post")
+            .AsUnread()
+            .Build();
+        await _client.PostAsJsonAsync("/api/posts/", post);
+
+        var futureTimestamp = DateTime.UtcNow.AddDays(1);
+
+        // Act
+        var response = await _client.GetAsync(
+            $"/api/posts/?modifiedAfter={Uri.EscapeDataString(futureTimestamp.ToString("O"))}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var posts = await response.Content.ReadFromJsonAsync<List<PostL>>();
+        posts.Should().NotBeNull();
+        posts!.Should().NotContain(p => p.RowKey == post.RowKey,
+            "no post modified before a future timestamp should be included in the delta");
+    }
+
+    [Fact]
+    public async Task GetPosts_WithoutModifiedAfter_ReturnsAllPosts()
+    {
+        // Arrange: create two known posts
+        var post1 = TestDataBuilder.Post()
+            .WithTitle("Baseline Post 1 — delta test")
+            .WithUrl("https://example.com/delta-baseline-1")
+            .AsUnread()
+            .Build();
+        var post2 = TestDataBuilder.Post()
+            .WithTitle("Baseline Post 2 — delta test")
+            .WithUrl("https://example.com/delta-baseline-2")
+            .AsUnread()
+            .Build();
+        await _client.PostAsJsonAsync("/api/posts/", post1);
+        await _client.PostAsJsonAsync("/api/posts/", post2);
+
+        // Act — no modifiedAfter parameter; should behave as before (non-breaking)
+        var response = await _client.GetAsync("/api/posts/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var posts = await response.Content.ReadFromJsonAsync<List<PostL>>();
+        posts.Should().NotBeNull();
+        posts!.Should().Contain(p => p.RowKey == post1.RowKey,
+            "omitting modifiedAfter must not change existing behaviour");
+        posts!.Should().Contain(p => p.RowKey == post2.RowKey,
+            "omitting modifiedAfter must not change existing behaviour");
+    }
+
+    [Fact]
+    public async Task GetPosts_WithModifiedAfter_MultipleResults()
+    {
+        // Arrange: one early post, two recent posts
+        var earlyPost = TestDataBuilder.Post()
+            .WithTitle("Early Post — multi delta test")
+            .WithUrl("https://example.com/delta-multi-early")
+            .AsUnread()
+            .Build();
+        await _client.PostAsJsonAsync("/api/posts/", earlyPost);
+
+        var threshold = DateTime.UtcNow;
+        await Task.Delay(150);
+
+        var recentPost1 = TestDataBuilder.Post()
+            .WithTitle("Recent Post 1 — multi delta test")
+            .WithUrl("https://example.com/delta-multi-recent-1")
+            .AsUnread()
+            .Build();
+        var recentPost2 = TestDataBuilder.Post()
+            .WithTitle("Recent Post 2 — multi delta test")
+            .WithUrl("https://example.com/delta-multi-recent-2")
+            .AsUnread()
+            .Build();
+        await _client.PostAsJsonAsync("/api/posts/", recentPost1);
+        await _client.PostAsJsonAsync("/api/posts/", recentPost2);
+
+        // Act
+        var response = await _client.GetAsync(
+            $"/api/posts/?modifiedAfter={Uri.EscapeDataString(threshold.ToString("O"))}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var posts = await response.Content.ReadFromJsonAsync<List<PostL>>();
+        posts.Should().NotBeNull();
+        posts!.Should().Contain(p => p.RowKey == recentPost1.RowKey,
+            "both posts created after the threshold should appear in delta results");
+        posts!.Should().Contain(p => p.RowKey == recentPost2.RowKey,
+            "both posts created after the threshold should appear in delta results");
+        posts!.Should().NotContain(p => p.RowKey == earlyPost.RowKey,
+            "the post created before the threshold should be excluded");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Notes delta — GET /api/notes/?modifiedAfter={timestamp}
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetNotes_WithModifiedAfter_ReturnsOnlyRecentNotes()
+    {
+        // Arrange: create an "old" note, then a "new" note after the threshold
+        var oldNote = TestDataBuilder.Note()
+            .WithComment("Old note — delta test A")
+            .WithPostId("delta-old-note-post")
+            .Build();
+        await _client.PostAsJsonAsync("/api/notes/note", oldNote);
+
+        var threshold = DateTime.UtcNow;
+        await Task.Delay(150);
+
+        var newNote = TestDataBuilder.Note()
+            .WithComment("New note — delta test A")
+            .WithPostId("delta-new-note-post")
+            .Build();
+        await _client.PostAsJsonAsync("/api/notes/note", newNote);
+
+        // Act
+        var response = await _client.GetAsync(
+            $"/api/notes/?modifiedAfter={Uri.EscapeDataString(threshold.ToString("O"))}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        notes.Should().NotBeNull();
+        notes!.Should().Contain(n => n.RowKey == newNote.RowKey,
+            "the note created after the threshold should appear in the delta results");
+        notes!.Should().NotContain(n => n.RowKey == oldNote.RowKey,
+            "the note created before the threshold should be excluded from delta results");
+    }
+
+    [Fact]
+    public async Task GetNotes_WithModifiedAfter_FutureTimestamp_ReturnsEmpty()
+    {
+        // Arrange: create a note that pre-dates a future threshold
+        var note = TestDataBuilder.Note()
+            .WithComment("Note — delta future test")
+            .WithPostId("delta-future-note-post")
+            .Build();
+        await _client.PostAsJsonAsync("/api/notes/note", note);
+
+        var futureTimestamp = DateTime.UtcNow.AddDays(1);
+
+        // Act
+        var response = await _client.GetAsync(
+            $"/api/notes/?modifiedAfter={Uri.EscapeDataString(futureTimestamp.ToString("O"))}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        notes.Should().NotBeNull();
+        notes!.Should().NotContain(n => n.RowKey == note.RowKey,
+            "no note modified before a future timestamp should be included in the delta");
+    }
+
+    [Fact]
+    public async Task GetNotes_WithoutModifiedAfter_ReturnsAllNotes()
+    {
+        // Arrange: create two known notes
+        var note1 = TestDataBuilder.Note()
+            .WithComment("Baseline note 1 — delta test")
+            .WithPostId("delta-baseline-note-post-1")
+            .Build();
+        var note2 = TestDataBuilder.Note()
+            .WithComment("Baseline note 2 — delta test")
+            .WithPostId("delta-baseline-note-post-2")
+            .Build();
+        await _client.PostAsJsonAsync("/api/notes/note", note1);
+        await _client.PostAsJsonAsync("/api/notes/note", note2);
+
+        // Act — no modifiedAfter parameter; should behave as before (non-breaking)
+        var response = await _client.GetAsync("/api/notes/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        notes.Should().NotBeNull();
+        notes!.Should().Contain(n => n.RowKey == note1.RowKey,
+            "omitting modifiedAfter must not change existing behaviour");
+        notes!.Should().Contain(n => n.RowKey == note2.RowKey,
+            "omitting modifiedAfter must not change existing behaviour");
+    }
+
+    [Fact]
+    public async Task GetNotes_WithModifiedAfter_MultipleResults()
+    {
+        // Arrange: one early note, two recent notes
+        var earlyNote = TestDataBuilder.Note()
+            .WithComment("Early note — multi delta test")
+            .WithPostId("delta-multi-early-note-post")
+            .Build();
+        await _client.PostAsJsonAsync("/api/notes/note", earlyNote);
+
+        var threshold = DateTime.UtcNow;
+        await Task.Delay(150);
+
+        var recentNote1 = TestDataBuilder.Note()
+            .WithComment("Recent note 1 — multi delta test")
+            .WithPostId("delta-multi-recent-note-post-1")
+            .Build();
+        var recentNote2 = TestDataBuilder.Note()
+            .WithComment("Recent note 2 — multi delta test")
+            .WithPostId("delta-multi-recent-note-post-2")
+            .Build();
+        await _client.PostAsJsonAsync("/api/notes/note", recentNote1);
+        await _client.PostAsJsonAsync("/api/notes/note", recentNote2);
+
+        // Act
+        var response = await _client.GetAsync(
+            $"/api/notes/?modifiedAfter={Uri.EscapeDataString(threshold.ToString("O"))}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        notes.Should().NotBeNull();
+        notes!.Should().Contain(n => n.RowKey == recentNote1.RowKey,
+            "both notes created after the threshold should appear in delta results");
+        notes!.Should().Contain(n => n.RowKey == recentNote2.RowKey,
+            "both notes created after the threshold should appear in delta results");
+        notes!.Should().NotContain(n => n.RowKey == earlyNote.RowKey,
+            "the note created before the threshold should be excluded");
+    }
+}

--- a/src/NoteBookmark.Api/DataStorageService.cs
+++ b/src/NoteBookmark.Api/DataStorageService.cs
@@ -115,7 +115,8 @@ public class DataStorageService(TableServiceClient tblClient, BlobServiceClient 
                                 Title = post.Title ?? string.Empty, 
                                 Url = post.Url ?? string.Empty, 
                                 Note = joined?.Comment ?? string.Empty, 
-                                NoteId = joined?.RowKey ?? string.Empty 
+                                NoteId = joined?.RowKey ?? string.Empty,
+                                DateModified = post.DateModified
                             };
 
         List<PostL> lstPosts = joinedResults.ToList();
@@ -133,6 +134,7 @@ public class DataStorageService(TableServiceClient tblClient, BlobServiceClient 
     public bool SavePost(Post post)
     {
         var tblPost = GetPostTable();
+        post.DateModified = DateTime.UtcNow;
         var existingPost = tblPost.Query<Post>(filter: $"RowKey eq '{post.RowKey}'").FirstOrDefault();
         if (existingPost != null)
         {
@@ -168,6 +170,7 @@ public class DataStorageService(TableServiceClient tblClient, BlobServiceClient 
     public void CreateNote(Note note)
     {
         var tblNote = GetNoteTable();
+        note.DateModified = DateTime.UtcNow;
         var existingNote = tblNote.Query<Note>(filter: $"RowKey eq '{note.RowKey}'").FirstOrDefault();
         if (existingNote != null)
         {

--- a/src/NoteBookmark.Api/NoteEnpoints.cs
+++ b/src/NoteBookmark.Api/NoteEnpoints.cs
@@ -34,6 +34,9 @@ public static class NoteEnpoints
 		endpoints.MapPut("/note", UpdateNote)
 			.WithDescription("Update an existing note");
 
+		endpoints.MapPatch("/note/{rowKey}", PatchNote)
+			.WithDescription("Partially update a note by its row key");
+
 		endpoints.MapDelete("/note/{rowKey}", DeleteNote)
 			.WithDescription("Delete a note");
 	}
@@ -67,11 +70,18 @@ public static class NoteEnpoints
 	}
 
 	static Results<Ok<List<Note>>, NotFound> GetNotes(TableServiceClient tblClient, 
-														BlobServiceClient blobClient)
+														BlobServiceClient blobClient,
+														DateTime? modifiedAfter = null)
 	{
 		var dataStorageService = new DataStorageService(tblClient, blobClient);
 		var notes = dataStorageService.GetNotes();
-		return notes == null ? TypedResults.NotFound() : TypedResults.Ok(notes);
+		if (notes == null) return TypedResults.NotFound();
+		if (modifiedAfter.HasValue)
+		{
+			var threshold = modifiedAfter.Value.ToUniversalTime();
+			notes = notes.Where(n => n.DateModified > threshold).ToList();
+		}
+		return TypedResults.Ok(notes);
 	}
 
 	static Results<Ok<List<ReadingNote>>, NotFound> GetNotesForSummary(string ReadingNotesId, 
@@ -163,5 +173,30 @@ public static class NoteEnpoints
 		var dataStorageService = new DataStorageService(tblClient, blobClient);
 		var result = dataStorageService.DeleteNote(rowKey);
 		return result ? TypedResults.Ok() : TypedResults.NotFound();
+	}
+
+	static Results<Ok<Note>, NotFound, BadRequest> PatchNote(string rowKey, Note note, 
+															TableServiceClient tblClient, 
+															BlobServiceClient blobClient)
+	{
+		try
+		{
+			var dataStorageService = new DataStorageService(tblClient, blobClient);
+			var existingNote = dataStorageService.GetNote(rowKey);
+			if (existingNote is null)
+			{
+				return TypedResults.NotFound();
+			}
+			note.RowKey = rowKey;
+			note.PartitionKey = existingNote.PartitionKey;
+			dataStorageService.CreateNote(note);
+			var updated = dataStorageService.GetNote(rowKey);
+			return TypedResults.Ok(updated!);
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"An error occurred while patching a note: {ex.Message}");
+			return TypedResults.BadRequest();
+		}
 	}
 }

--- a/src/NoteBookmark.Api/PostEndpoints.cs
+++ b/src/NoteBookmark.Api/PostEndpoints.cs
@@ -27,18 +27,32 @@ public static class PostEndpoints
 			.WithDescription("Extract post details from URL and save the post");
 		endpoints.MapDelete("/{id}", DeletePost)
 			.WithDescription("Delete a post by id");
+		endpoints.MapPatch("/{id}", PatchPost)
+			.WithDescription("Partially update a post by id");
 	}
 
-	static List<PostL> GetUnreadPosts(TableServiceClient tblClient, BlobServiceClient blobClient)
+	static List<PostL> GetUnreadPosts(TableServiceClient tblClient, BlobServiceClient blobClient, DateTime? modifiedAfter = null)
 	{
 		var dataStorageService = new DataStorageService(tblClient, blobClient);
-		return dataStorageService.GetFilteredPosts("is_read eq false");
+		var posts = dataStorageService.GetFilteredPosts("is_read eq false");
+		if (modifiedAfter.HasValue)
+		{
+			var threshold = modifiedAfter.Value.ToUniversalTime();
+			posts = posts.Where(p => p.DateModified > threshold).ToList();
+		}
+		return posts;
 	}
 
-	static List<PostL> GetReadPosts(TableServiceClient tblClient, BlobServiceClient blobClient)
+	static List<PostL> GetReadPosts(TableServiceClient tblClient, BlobServiceClient blobClient, DateTime? modifiedAfter = null)
 	{
 		var dataStorageService = new DataStorageService(tblClient, blobClient);
-		return dataStorageService.GetFilteredPosts("is_read eq true");
+		var posts = dataStorageService.GetFilteredPosts("is_read eq true");
+		if (modifiedAfter.HasValue)
+		{
+			var threshold = modifiedAfter.Value.ToUniversalTime();
+			posts = posts.Where(p => p.DateModified > threshold).ToList();
+		}
+		return posts;
 	}
 
 	static Results<Ok<Post>, NotFound> Get(string id, TableServiceClient tblClient, BlobServiceClient blobClient)
@@ -98,6 +112,24 @@ public static class PostEndpoints
 		return TypedResults.NotFound();
 	}
 
+	static Results<Ok<Post>, NotFound, BadRequest> PatchPost(string id, Post post, TableServiceClient tblClient, BlobServiceClient blobClient)
+	{
+		var dataStorageService = new DataStorageService(tblClient, blobClient);
+		var existingPost = dataStorageService.GetPost(id);
+		if (existingPost is null)
+		{
+			return TypedResults.NotFound();
+		}
+		post.RowKey = id;
+		post.PartitionKey = existingPost.PartitionKey;
+		if (dataStorageService.SavePost(post))
+		{
+			var updated = dataStorageService.GetPost(id);
+			return TypedResults.Ok(updated!);
+		}
+		return TypedResults.BadRequest();
+	}
+
 	private static async Task<Post?> ExtractPostDetailsFromUrl(string url)
     {
         var web = new HtmlWeb();
@@ -146,7 +178,8 @@ public static class PostEndpoints
 			Date_published = publicationDate.ToString("yyyy-MM-ddTHH:mm:ssZ"),
 			is_read = false,
 			RowKey = postGuid,
-			Id = postGuid
+			Id = postGuid,
+			DateModified = DateTime.UtcNow
 		};
 		return post;
     }

--- a/src/NoteBookmark.Domain/Note.cs
+++ b/src/NoteBookmark.Domain/Note.cs
@@ -9,6 +9,7 @@ public class Note : ITableEntity
         PartitionKey = DateTime.UtcNow.ToString("yyyy-MM");
         RowKey = Guid.NewGuid().ToString();
         DateAdded = DateTime.UtcNow;
+        DateModified = DateTime.UtcNow;
     }
 
 
@@ -17,6 +18,9 @@ public class Note : ITableEntity
 
     [DataMember(Name = "date_added")]
     public DateTime DateAdded { get; set; }
+
+    [DataMember(Name = "date_modified")]
+    public DateTime DateModified { get; set; }
 
     [DataMember(Name = "tags")]
     public string? Tags { get; set; }

--- a/src/NoteBookmark.Domain/Post.cs
+++ b/src/NoteBookmark.Domain/Post.cs
@@ -52,6 +52,9 @@ public class Post : ITableEntity
     [DataMember(Name="id")]
     public string? Id { get; set; }
 
+    [DataMember(Name = "date_modified")]
+    public DateTime DateModified { get; set; } = DateTime.UtcNow;
+
     public required string PartitionKey { get; set; }
 
     public required string RowKey { get; set; }

--- a/src/NoteBookmark.Domain/PostL.cs
+++ b/src/NoteBookmark.Domain/PostL.cs
@@ -36,6 +36,7 @@ public class PostL : ITableEntity
     // Note Properties
     public string? NoteId { get; set; }
     public string? Note { get; set; }
+    public DateTime DateModified { get; set; }
 }
 
 


### PR DESCRIPTION
## Summary

Adds `DateModified` (UTC timestamp) to `Post` and `Note` domain models, and extends GET list endpoints with an optional `modifiedAfter` query parameter for mobile delta sync.

## Changes

### Domain
- `Post.DateModified` — `DateTime` UTC, defaults to `DateTime.UtcNow` (Azure SDK requires UTC)
- `Note.DateModified` — `DateTime` UTC, set in constructor
- `PostL.DateModified` — exposed in list responses

### API
- `GET /api/posts/?modifiedAfter={ISO8601}` — filters unread posts by `DateModified` (non-breaking)
- `GET /api/posts/read?modifiedAfter={ISO8601}` — filters read posts by `DateModified` (non-breaking)
- `GET /api/notes/?modifiedAfter={ISO8601}` — filters notes by `DateModified` (non-breaking)
- `PATCH /api/posts/{id}` — updates post, sets `DateModified = DateTime.UtcNow`
- `PATCH /api/notes/note/{rowKey}` — updates note, sets `DateModified = DateTime.UtcNow`

### Storage
- `DataStorageService.SavePost` sets `DateModified = DateTime.UtcNow` on every write
- `DataStorageService.CreateNote` sets `DateModified = DateTime.UtcNow` on every write
- In-memory filtering used for `modifiedAfter` (safe across all Azure Table Storage tiers)

### Tests
- 12 new endpoint integration tests in `DeltaApiTests.cs`
- All 20 delta tests pass (8 Biggs proactive integration tests + 12 new endpoint tests)
- No pre-existing tests broken

Closes #121