### PR TITLE
feat: Sync engine + Android APK build (closes #126, #127)

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -1,0 +1,54 @@
+name: Build Android APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DEFAULT_DOTNET_VERSION: "10.0.x"
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    name: Build Android Release APK
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DEFAULT_DOTNET_VERSION }}
+
+      - name: Install MAUI Android workload
+        run: dotnet workload install maui-android
+
+      - name: Decode keystore
+        if: env.ANDROID_KEYSTORE_BASE64 != ''
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > ${{ github.workspace }}/android.keystore
+
+      - name: Publish Android APK
+        run: >
+          dotnet publish src/NoteBookmark.MauiApp/NoteBookmark.MauiApp.csproj
+          -f net10.0-android
+          -c Release
+          -p:AndroidPackageFormat=apk
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/android.keystore
+          ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: notebookmark-android-apk
+          path: src/NoteBookmark.MauiApp/bin/Release/net10.0-android/publish/*.apk

--- a/src/NoteBookmark.Domain/Note.cs
+++ b/src/NoteBookmark.Domain/Note.cs
@@ -22,6 +22,8 @@ public class Note : ITableEntity
     [DataMember(Name = "date_modified")]
     public DateTime DateModified { get; set; }
 
+    public bool IsDeleted { get; set; }
+
     [DataMember(Name = "tags")]
     public string? Tags { get; set; }
 

--- a/src/NoteBookmark.Domain/Post.cs
+++ b/src/NoteBookmark.Domain/Post.cs
@@ -55,6 +55,8 @@ public class Post : ITableEntity
     [DataMember(Name = "date_modified")]
     public DateTime DateModified { get; set; } = DateTime.UtcNow;
 
+    public bool IsDeleted { get; set; }
+
     public required string PartitionKey { get; set; }
 
     public required string RowKey { get; set; }

--- a/src/NoteBookmark.MauiApp.Tests/NoteBookmark.MauiApp.Tests.csproj
+++ b/src/NoteBookmark.MauiApp.Tests/NoteBookmark.MauiApp.Tests.csproj
@@ -26,12 +26,16 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NoteBookmark.Domain\NoteBookmark.Domain.csproj" />
+    <ProjectReference Include="..\NoteBookmark.SharedUI\NoteBookmark.SharedUI.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\NoteBookmark.MauiApp\Data\LocalModels.cs" Link="Data\LocalModels.cs" />
     <Compile Include="..\NoteBookmark.MauiApp\Data\ILocalDataService.cs" Link="Data\ILocalDataService.cs" />
     <Compile Include="..\NoteBookmark.MauiApp\Data\LocalDataService.cs" Link="Data\LocalDataService.cs" />
+    <Compile Include="..\NoteBookmark.MauiApp\Data\ISyncApiClient.cs" Link="Data\ISyncApiClient.cs" />
+    <Compile Include="..\NoteBookmark.MauiApp\Data\SyncService.cs" Link="Data\SyncService.cs" />
+    <Compile Include="..\NoteBookmark.MauiApp\Data\SyncApiClient.cs" Link="Data\SyncApiClient.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
+++ b/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NoteBookmark.Domain;
+using NoteBookmark.MauiApp.Data;
+using Xunit;
+
+namespace NoteBookmark.MauiApp.Tests;
+
+public class SyncServiceTests
+{
+    private readonly Mock<ISyncApiClient> _apiClientMock;
+    private readonly Mock<ILocalDataService> _localDataServiceMock;
+    private readonly SyncService _sut;
+
+    public SyncServiceTests()
+    {
+        _apiClientMock = new Mock<ISyncApiClient>();
+        _localDataServiceMock = new Mock<ILocalDataService>();
+        _sut = new SyncService(_apiClientMock.Object, _localDataServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task PushPhase_ShouldSendPendingPostsAndClearFlag()
+    {
+        var pendingPost = new Post
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Pending",
+            DateModified = DateTime.UtcNow,
+            IsDeleted = false
+        };
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync())
+            .ReturnsAsync(new List<Post> { pendingPost });
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync())
+            .ReturnsAsync(new List<Note>());
+        _apiClientMock.Setup(c => c.SavePost(It.IsAny<Post>())).ReturnsAsync(true);
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+
+        await _sut.SyncAsync();
+
+        _apiClientMock.Verify(c => c.SavePost(pendingPost), Times.Once);
+        _localDataServiceMock.Verify(c => c.MarkSyncedAsync("post1", true), Times.Once);
+    }
+
+    [Fact]
+    public async Task PushPhase_ShouldSendPendingNotesAndClearFlag()
+    {
+        var pendingNote = new Note
+        {
+            RowKey = "note1",
+            PartitionKey = "pk",
+            Comment = "Pending note",
+            DateModified = DateTime.UtcNow,
+            IsDeleted = false
+        };
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync())
+            .ReturnsAsync(new List<Post>());
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync())
+            .ReturnsAsync(new List<Note> { pendingNote });
+        _apiClientMock.Setup(c => c.UpdateNote(It.IsAny<Note>())).ReturnsAsync(true);
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+
+        await _sut.SyncAsync();
+
+        _apiClientMock.Verify(c => c.UpdateNote(pendingNote), Times.Once);
+        _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
+    }
+
+    [Fact]
+    public async Task PushPhase_ShouldSendSoftDeletedPostsAsDelete()
+    {
+        var deletedPost = new Post
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Deleted",
+            DateModified = DateTime.UtcNow,
+            IsDeleted = true
+        };
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync())
+            .ReturnsAsync(new List<Post> { deletedPost });
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync())
+            .ReturnsAsync(new List<Note>());
+        _apiClientMock.Setup(c => c.DeletePost("post1")).ReturnsAsync(true);
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+
+        await _sut.SyncAsync();
+
+        _apiClientMock.Verify(c => c.DeletePost("post1"), Times.Once);
+        _localDataServiceMock.Verify(c => c.MarkSyncedAsync("post1", true), Times.Once);
+    }
+
+    [Fact]
+    public async Task PushPhase_ShouldSendSoftDeletedNotesAsDelete()
+    {
+        var deletedNote = new Note
+        {
+            RowKey = "note1",
+            PartitionKey = "pk",
+            Comment = "Deleted note",
+            DateModified = DateTime.UtcNow,
+            IsDeleted = true
+        };
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync())
+            .ReturnsAsync(new List<Post>());
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync())
+            .ReturnsAsync(new List<Note> { deletedNote });
+        _apiClientMock.Setup(c => c.DeleteNote("note1")).ReturnsAsync(true);
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+
+        await _sut.SyncAsync();
+
+        _apiClientMock.Verify(c => c.DeleteNote("note1"), Times.Once);
+        _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
+    }
+
+    [Fact]
+    public async Task PullPhase_RemoteNewer_ShouldOverwriteLocal()
+    {
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync()).ReturnsAsync(new List<Post>());
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note>());
+
+        var remotePostL = new PostL
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Remote",
+            DateModified = DateTime.UtcNow.AddMinutes(5)
+        };
+        var remotePost = new Post
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Remote",
+            DateModified = DateTime.UtcNow.AddMinutes(5)
+        };
+        var localPost = new Post
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Local",
+            DateModified = DateTime.UtcNow
+        };
+
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>()))
+            .ReturnsAsync(new List<PostL> { remotePostL });
+        _apiClientMock.Setup(c => c.GetPost("post1")).ReturnsAsync(remotePost);
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+        _localDataServiceMock.Setup(c => c.GetPostAsync("post1")).ReturnsAsync(localPost);
+
+        await _sut.SyncAsync();
+
+        _localDataServiceMock.Verify(c => c.SavePostAsync(It.Is<Post>(p => p.Title == "Remote"), false), Times.Once);
+    }
+
+    [Fact]
+    public async Task PullPhase_LocalNewer_ShouldKeepLocal()
+    {
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync()).ReturnsAsync(new List<Post>());
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note>());
+
+        var remotePostL = new PostL
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Remote",
+            DateModified = DateTime.UtcNow.AddMinutes(-5)
+        };
+        var localPost = new Post
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Local",
+            DateModified = DateTime.UtcNow
+        };
+
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>()))
+            .ReturnsAsync(new List<PostL> { remotePostL });
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+        _localDataServiceMock.Setup(c => c.GetPostAsync("post1")).ReturnsAsync(localPost);
+
+        await _sut.SyncAsync();
+
+        _localDataServiceMock.Verify(c => c.SavePostAsync(It.IsAny<Post>(), false), Times.Never);
+    }
+
+    [Fact]
+    public async Task PullPhase_NoLocal_ShouldSaveRemote()
+    {
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync()).ReturnsAsync(new List<Post>());
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note>());
+
+        var remotePostL = new PostL
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Remote",
+            DateModified = DateTime.UtcNow
+        };
+        var remotePost = new Post
+        {
+            Id = "post1",
+            RowKey = "post1",
+            PartitionKey = "pk",
+            Title = "Remote",
+            DateModified = DateTime.UtcNow
+        };
+
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>()))
+            .ReturnsAsync(new List<PostL> { remotePostL });
+        _apiClientMock.Setup(c => c.GetPost("post1")).ReturnsAsync(remotePost);
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+        _localDataServiceMock.Setup(c => c.GetPostAsync("post1")).ReturnsAsync((Post?)null);
+
+        await _sut.SyncAsync();
+
+        _localDataServiceMock.Verify(c => c.SavePostAsync(It.Is<Post>(p => p.Title == "Remote"), false), Times.Once);
+    }
+
+    [Fact]
+    public async Task PullPhase_Notes_RemoteNewer_ShouldOverwriteLocal()
+    {
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync()).ReturnsAsync(new List<Post>());
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note>());
+
+        var remoteNote = new Note
+        {
+            RowKey = "note1",
+            PartitionKey = "pk",
+            Comment = "Remote",
+            DateModified = DateTime.UtcNow.AddMinutes(5)
+        };
+        var localNote = new Note
+        {
+            RowKey = "note1",
+            PartitionKey = "pk",
+            Comment = "Local",
+            DateModified = DateTime.UtcNow
+        };
+
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>()))
+            .ReturnsAsync(new List<Note> { remoteNote });
+        _localDataServiceMock.Setup(c => c.GetNoteAsync("note1")).ReturnsAsync(localNote);
+
+        await _sut.SyncAsync();
+
+        _localDataServiceMock.Verify(c => c.SaveNoteAsync(It.Is<Note>(n => n.Comment == "Remote"), false), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncAsync_ShouldNotRunConcurrently()
+    {
+        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync())
+            .Returns(async () =>
+            {
+                await Task.Delay(50);
+                return new List<Post>();
+            });
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note>());
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+
+        var task1 = _sut.SyncAsync();
+        var task2 = _sut.SyncAsync();
+        await Task.WhenAll(task1, task2);
+
+        _localDataServiceMock.Verify(c => c.GetPendingSyncPostsAsync(), Times.Once);
+    }
+}

--- a/src/NoteBookmark.MauiApp/App.xaml.cs
+++ b/src/NoteBookmark.MauiApp/App.xaml.cs
@@ -1,15 +1,22 @@
-﻿using NoteBookmark.MauiApp.Auth;
+﻿using Microsoft.Maui.Networking;
+using NoteBookmark.MauiApp.Auth;
+using NoteBookmark.MauiApp.Data;
 
 namespace NoteBookmark.MauiApp;
 
 public partial class App : Application
 {
     private readonly IAuthService _authService;
+    private readonly ISyncService _syncService;
+    private readonly IConnectivity _connectivity;
 
-    public App(IAuthService authService)
+    public App(IAuthService authService, ISyncService syncService, IConnectivity connectivity)
     {
         InitializeComponent();
         _authService = authService;
+        _syncService = syncService;
+        _connectivity = connectivity;
+        _connectivity.ConnectivityChanged += OnConnectivityChanged;
     }
 
     protected override Window CreateWindow(IActivationState? activationState)
@@ -21,5 +28,19 @@ public partial class App : Application
     {
         base.OnStart();
         await _authService.InitializeAsync();
+    }
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+        _ = _syncService.SyncAsync();
+    }
+
+    private void OnConnectivityChanged(object? sender, ConnectivityChangedEventArgs e)
+    {
+        if (e.NetworkAccess == NetworkAccess.Internet)
+        {
+            _ = _syncService.SyncAsync();
+        }
     }
 }

--- a/src/NoteBookmark.MauiApp/Data/ISyncApiClient.cs
+++ b/src/NoteBookmark.MauiApp/Data/ISyncApiClient.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NoteBookmark.Domain;
+
+namespace NoteBookmark.MauiApp.Data;
+
+public interface ISyncApiClient
+{
+    Task<List<PostL>> GetPostsModifiedAfter(DateTime modifiedAfter);
+    Task<List<Note>> GetNotesModifiedAfter(DateTime modifiedAfter);
+    Task<Post?> GetPost(string id);
+    Task<bool> SavePost(Post post);
+    Task<bool> DeletePost(string id);
+    Task<bool> UpdateNote(Note note);
+    Task<bool> DeleteNote(string rowKey);
+}

--- a/src/NoteBookmark.MauiApp/Data/LocalModels.cs
+++ b/src/NoteBookmark.MauiApp/Data/LocalModels.cs
@@ -49,6 +49,7 @@ public class LocalPost
         Rendered_pages = Rendered_pages,
         is_read = is_read,
         DateModified = DateModified,
+        IsDeleted = IsDeleted,
         PartitionKey = PartitionKey,
         RowKey = RowKey
     };
@@ -104,7 +105,8 @@ public class LocalNote
         DateModified = DateModified,
         Tags = Tags,
         PostId = PostId,
-        Category = Category
+        Category = Category,
+        IsDeleted = IsDeleted
     };
 
     public static LocalNote FromDomain(Note note, bool isPendingSync = false, bool isDeleted = false) => new LocalNote

--- a/src/NoteBookmark.MauiApp/Data/SyncApiClient.cs
+++ b/src/NoteBookmark.MauiApp/Data/SyncApiClient.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NoteBookmark.Domain;
+using NoteBookmark.SharedUI;
+
+namespace NoteBookmark.MauiApp.Data;
+
+public class SyncApiClient(PostNoteClient client) : ISyncApiClient
+{
+    public Task<List<PostL>> GetPostsModifiedAfter(DateTime modifiedAfter) => client.GetPostsModifiedAfter(modifiedAfter);
+    public Task<List<Note>> GetNotesModifiedAfter(DateTime modifiedAfter) => client.GetNotesModifiedAfter(modifiedAfter);
+    public Task<Post?> GetPost(string id) => client.GetPost(id);
+    public Task<bool> SavePost(Post post) => client.SavePost(post);
+    public Task<bool> DeletePost(string id) => client.DeletePost(id);
+    public Task<bool> UpdateNote(Note note) => client.UpdateNote(note);
+    public Task<bool> DeleteNote(string rowKey) => client.DeleteNote(rowKey);
+}

--- a/src/NoteBookmark.MauiApp/Data/SyncService.cs
+++ b/src/NoteBookmark.MauiApp/Data/SyncService.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NoteBookmark.Domain;
+
+namespace NoteBookmark.MauiApp.Data;
+
+public interface ISyncService
+{
+    Task SyncAsync();
+    bool IsSyncing { get; }
+}
+
+public class SyncService(ISyncApiClient apiClient, ILocalDataService localDataService) : ISyncService
+{
+    private const string LastSyncTimestampKey = "LastSyncTimestamp";
+    private bool _isSyncing;
+
+    public bool IsSyncing => _isSyncing;
+
+    public async Task SyncAsync()
+    {
+        if (_isSyncing) return;
+
+        _isSyncing = true;
+        try
+        {
+            await PushAsync();
+            await PullAsync();
+        }
+        finally
+        {
+            _isSyncing = false;
+        }
+    }
+
+    private async Task PushAsync()
+    {
+        // Push posts
+        var pendingPosts = await localDataService.GetPendingSyncPostsAsync();
+        foreach (var post in pendingPosts)
+        {
+            var id = post.Id ?? post.RowKey;
+            bool success;
+            if (post.IsDeleted)
+            {
+                success = await apiClient.DeletePost(id);
+            }
+            else
+            {
+                success = await apiClient.SavePost(post);
+            }
+
+            if (success)
+            {
+                await localDataService.MarkSyncedAsync(id, isPost: true);
+            }
+        }
+
+        // Push notes
+        var pendingNotes = await localDataService.GetPendingSyncNotesAsync();
+        foreach (var note in pendingNotes)
+        {
+            bool success;
+            if (note.IsDeleted)
+            {
+                success = await apiClient.DeleteNote(note.RowKey);
+            }
+            else
+            {
+                success = await apiClient.UpdateNote(note);
+            }
+
+            if (success)
+            {
+                await localDataService.MarkSyncedAsync(note.RowKey, isPost: false);
+            }
+        }
+    }
+
+    private async Task PullAsync()
+    {
+        var lastSyncStr = await GetPreferenceAsync(LastSyncTimestampKey);
+        DateTime? lastSync = null;
+        if (!string.IsNullOrEmpty(lastSyncStr) && DateTime.TryParse(lastSyncStr, out var parsed))
+        {
+            lastSync = parsed.ToUniversalTime();
+        }
+
+        // Pull posts
+        var remotePostList = await apiClient.GetPostsModifiedAfter(lastSync ?? DateTime.MinValue);
+        foreach (var remotePostL in remotePostList)
+        {
+            var localPost = await localDataService.GetPostAsync(remotePostL.Id ?? remotePostL.RowKey);
+            if (localPost is null || remotePostL.DateModified > localPost.DateModified)
+            {
+                var fullPost = await apiClient.GetPost(remotePostL.Id ?? remotePostL.RowKey);
+                if (fullPost is not null)
+                {
+                    await localDataService.SavePostAsync(fullPost, isPendingSync: false);
+                }
+            }
+        }
+
+        // Pull notes
+        var remoteNotes = await apiClient.GetNotesModifiedAfter(lastSync ?? DateTime.MinValue);
+        foreach (var remoteNote in remoteNotes)
+        {
+            var localNote = await localDataService.GetNoteAsync(remoteNote.RowKey);
+            if (localNote is null || remoteNote.DateModified > localNote.DateModified)
+            {
+                await localDataService.SaveNoteAsync(remoteNote, isPendingSync: false);
+            }
+        }
+
+        await SetPreferenceAsync(LastSyncTimestampKey, DateTime.UtcNow.ToString("O"));
+    }
+
+    private static async Task<string?> GetPreferenceAsync(string key)
+    {
+#if NOT_MAUI
+        return null;
+#else
+        return await Microsoft.Maui.Storage.Preferences.GetAsync(key, defaultValue: string.Empty);
+#endif
+    }
+
+    private static async Task SetPreferenceAsync(string key, string value)
+    {
+#if NOT_MAUI
+        await Task.CompletedTask;
+#else
+        await Microsoft.Maui.Storage.Preferences.SetAsync(key, value);
+#endif
+    }
+}

--- a/src/NoteBookmark.MauiApp/MauiProgram.cs
+++ b/src/NoteBookmark.MauiApp/MauiProgram.cs
@@ -39,6 +39,8 @@ public static class MauiProgram
         });
 
         builder.Services.AddSingleton<NoteBookmark.SharedUI.IDataService, NoteBookmark.MauiApp.Data.OfflineDataService>();
+        builder.Services.AddSingleton<NoteBookmark.MauiApp.Data.ISyncApiClient, NoteBookmark.MauiApp.Data.SyncApiClient>();
+        builder.Services.AddSingleton<NoteBookmark.MauiApp.Data.ISyncService, NoteBookmark.MauiApp.Data.SyncService>();
 
         builder.Services.AddFluentUIComponents();
 

--- a/src/NoteBookmark.MauiApp/NoteBookmark.MauiApp.csproj
+++ b/src/NoteBookmark.MauiApp/NoteBookmark.MauiApp.csproj
@@ -51,6 +51,15 @@
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     </PropertyGroup>
 
+    <!-- Android release signing configuration (secrets injected via environment variables in CI) -->
+    <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and '$(Configuration)' == 'Release'">
+        <AndroidKeyStore Condition="'$(ANDROID_KEYSTORE_PATH)' != ''">true</AndroidKeyStore>
+        <AndroidSigningKeyStore Condition="'$(ANDROID_KEYSTORE_PATH)' != ''">$(ANDROID_KEYSTORE_PATH)</AndroidSigningKeyStore>
+        <AndroidSigningKeyAlias Condition="'$(ANDROID_KEYSTORE_ALIAS)' != ''">$(ANDROID_KEYSTORE_ALIAS)</AndroidSigningKeyAlias>
+        <AndroidSigningKeyPass Condition="'$(ANDROID_KEYSTORE_PASSWORD)' != ''">$(ANDROID_KEYSTORE_PASSWORD)</AndroidSigningKeyPass>
+        <AndroidSigningStorePass Condition="'$(ANDROID_KEYSTORE_PASSWORD)' != ''">$(ANDROID_KEYSTORE_PASSWORD)</AndroidSigningStorePass>
+    </PropertyGroup>
+
     <ItemGroup>
         <!-- App Icon -->
         <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />

--- a/src/NoteBookmark.SharedUI/PostNoteClient.cs
+++ b/src/NoteBookmark.SharedUI/PostNoteClient.cs
@@ -173,4 +173,19 @@ public class PostNoteClient(HttpClient httpClient) : IDataService
         var response = await httpClient.PostAsJsonAsync($"api/summary/{number}/markdown", request);
         return response.IsSuccessStatusCode;
     }
+
+    public async Task<List<PostL>> GetPostsModifiedAfter(DateTime modifiedAfter)
+    {
+        var encoded = System.Web.HttpUtility.UrlEncode(modifiedAfter.ToUniversalTime().ToString("O"));
+        var unread = await httpClient.GetFromJsonAsync<List<PostL>>($"api/posts?modifiedAfter={encoded}") ?? new List<PostL>();
+        var read = await httpClient.GetFromJsonAsync<List<PostL>>($"api/posts/read?modifiedAfter={encoded}") ?? new List<PostL>();
+        return unread.Concat(read).ToList();
+    }
+
+    public async Task<List<Note>> GetNotesModifiedAfter(DateTime modifiedAfter)
+    {
+        var encoded = System.Web.HttpUtility.UrlEncode(modifiedAfter.ToUniversalTime().ToString("O"));
+        var notes = await httpClient.GetFromJsonAsync<List<Note>>($"api/notes?modifiedAfter={encoded}");
+        return notes ?? new List<Note>();
+    }
 }


### PR DESCRIPTION
## Summary

Implements the final two issues for epic #110:

### #126 — Sync engine: push + pull + last-write-wins
- `ISyncService` / `SyncService` with push and pull phases
- Push: sends all `IsPendingSync=true` posts and notes to the API; soft-deleted records are pushed as deletes
- Pull: fetches remote changes since `LastSyncTimestamp`, applies last-write-wins conflict resolution using `DateModified`
- `LastSyncTimestamp` persisted in MAUI `Preferences`
- Triggered on `App.OnResume` and `Connectivity.ConnectivityChanged` (online transition)
- Delta sync methods added to `PostNoteClient` (`GetPostsModifiedAfter`, `GetNotesModifiedAfter`)
- `ISyncApiClient` adapter for testability
- Unit tests for push, pull, conflict resolution, and concurrency guard

### #127 — Android APK build configuration
- Release build signing properties in `NoteBookmark.MauiApp.csproj` (reads from environment variables)
- GitHub Actions workflow `.github/workflows/build-android-apk.yml` to build and publish APK on tag push
- Workflow expects keystore via `ANDROID_KEYSTORE_BASE64` secret and signing credentials via GitHub Actions secrets

## Acceptance Criteria
- [x] `SyncService` implemented with push and pull phases
- [x] Triggered on app resume and connectivity restored
- [x] Last-write-wins applied correctly on both sides
- [x] `LastSyncTimestamp` persisted in `Preferences`
- [x] Unit tests pass for push, pull, and conflict resolution
- [x] Android release build profile configured
- [x] GitHub Actions workflow for APK build