### PR TITLE
Rework Sync Service and Add Force Sync Button

### DIFF
--- a/src/NoteBookmark.Api/DataStorageService.cs
+++ b/src/NoteBookmark.Api/DataStorageService.cs
@@ -170,6 +170,9 @@ public class DataStorageService(TableServiceClient tblClient, BlobServiceClient 
     public void CreateNote(Note note)
     {
         var tblNote = GetNoteTable();
+        note.DateAdded = note.DateAdded.Kind == DateTimeKind.Unspecified 
+            ? DateTime.SpecifyKind(note.DateAdded, DateTimeKind.Utc) 
+            : note.DateAdded.ToUniversalTime();
         note.DateModified = DateTime.UtcNow;
         var existingNote = tblNote.Query<Note>(filter: $"RowKey eq '{note.RowKey}'").FirstOrDefault();
         if (existingNote != null)

--- a/src/NoteBookmark.Api/NoteEnpoints.cs
+++ b/src/NoteBookmark.Api/NoteEnpoints.cs
@@ -41,7 +41,7 @@ public static class NoteEnpoints
 			.WithDescription("Delete a note");
 	}
 
-	static Results<Created<Note>, BadRequest> CreateNote(Note note, 
+	static Results<Created<Note>, BadRequest<string>> CreateNote(Note note, 
 														TableServiceClient tblClient, 
 														BlobServiceClient blobClient)
 	{
@@ -49,7 +49,7 @@ public static class NoteEnpoints
 		{
 			if (!note.Validate())
 			{
-				return TypedResults.BadRequest();
+				return TypedResults.BadRequest("Validation failed: Comment must not be empty.");
 			}
 			
 			var dataStorageService = new DataStorageService(tblClient, blobClient);
@@ -65,7 +65,7 @@ public static class NoteEnpoints
 		catch (Exception ex)
 		{
 			Console.WriteLine($"An error occurred while creating a note: {ex.Message}");
-			return TypedResults.BadRequest();
+			return TypedResults.BadRequest(ex.ToString());
 		}
 	}
 

--- a/src/NoteBookmark.Domain/Note.cs
+++ b/src/NoteBookmark.Domain/Note.cs
@@ -24,6 +24,9 @@ public class Note : ITableEntity
 
     public bool IsDeleted { get; set; }
 
+    [DataMember(Name = "created_offline")]
+    public bool CreatedOffline { get; set; }
+
     [DataMember(Name = "tags")]
     public string? Tags { get; set; }
 

--- a/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
+++ b/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
@@ -48,13 +48,13 @@ public class SyncServiceTests
             .ReturnsAsync(new List<Post>());
         _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync())
             .ReturnsAsync(new List<Note> { pendingNote });
-        _apiClientMock.Setup(c => c.UpdateNote(It.IsAny<Note>())).ReturnsAsync(true);
+        _apiClientMock.Setup(c => c.CreateNote(It.IsAny<Note>())).ReturnsAsync(true);
         _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
         _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
 
         await _sut.SyncAsync();
 
-        _apiClientMock.Verify(c => c.UpdateNote(pendingNote), Times.Once);
+        _apiClientMock.Verify(c => c.CreateNote(pendingNote), Times.Once);
         _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
     }
 
@@ -392,7 +392,7 @@ public class SyncServiceTests
         _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note> { pendingNote });
 
         _apiClientMock.Setup(c => c.GetNote("note1")).ThrowsAsync(new System.Net.Http.HttpRequestException("Not found", null, System.Net.HttpStatusCode.NotFound));
-        _apiClientMock.Setup(c => c.UpdateNote(It.IsAny<Note>())).ReturnsAsync(true);
+        _apiClientMock.Setup(c => c.CreateNote(It.IsAny<Note>())).ReturnsAsync(true);
 
         _apiClientMock.Setup(c => c.GetPostsModifiedAfter(DateTime.MinValue)).ReturnsAsync(new List<PostL>());
         _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
@@ -407,7 +407,7 @@ public class SyncServiceTests
 
         conflictMessage.Should().NotBeNull();
         conflictMessage.Should().Contain("deleted online");
-        _apiClientMock.Verify(c => c.UpdateNote(pendingNote), Times.Once);
+        _apiClientMock.Verify(c => c.CreateNote(pendingNote), Times.Once);
         _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
     }
 }

--- a/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
+++ b/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
@@ -350,7 +350,7 @@ public class SyncServiceTests
         conflictMessage.Should().Contain("conflict");
         _apiClientMock.Verify(c => c.UpdateNote(pendingNote), Times.Once);
         _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
-        _localDataServiceMock.Verify(c => c.SaveNoteAsync(It.IsAny<Note>(), It.IsAny<bool>()), Times.Never);
+        _localDataServiceMock.Verify(c => c.SaveNoteAsync(It.Is<Note>(n => !n.CreatedOffline), false), Times.Once);
     }
 
     [Fact]
@@ -408,6 +408,36 @@ public class SyncServiceTests
         conflictMessage.Should().NotBeNull();
         conflictMessage.Should().Contain("deleted online");
         _apiClientMock.Verify(c => c.CreateNote(pendingNote), Times.Once);
+        _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
+    }
+
+    [Fact]
+    public async Task PushPhase_ShouldSyncNoteDirectlyAndClearCreatedOfflineFlag_WhenNoteCreatedOffline()
+    {
+        var lastSync = new DateTime(2026, 7, 3, 10, 0, 0, DateTimeKind.Utc);
+        SyncService.SetInMemoryPreference("LastSyncTimestamp", lastSync.ToString("O"));
+
+        var pendingNote = new Note
+        {
+            RowKey = "note1",
+            PartitionKey = "pk",
+            Comment = "Created Offline",
+            DateModified = DateTime.UtcNow,
+            DateAdded = lastSync.AddMinutes(5),
+            CreatedOffline = true
+        };
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note> { pendingNote });
+        _apiClientMock.Setup(c => c.CreateNote(It.IsAny<Note>())).ReturnsAsync(true);
+
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(DateTime.MinValue)).ReturnsAsync(new List<PostL>());
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+
+        await _sut.SyncAsync();
+
+        // Verify GetNote was never called because CreatedOffline is true (bypassing conflict check)
+        _apiClientMock.Verify(c => c.GetNote("note1"), Times.Never);
+        _apiClientMock.Verify(c => c.CreateNote(It.Is<Note>(n => !n.CreatedOffline)), Times.Once);
+        _localDataServiceMock.Verify(c => c.SaveNoteAsync(It.Is<Note>(n => !n.CreatedOffline), false), Times.Once);
         _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
     }
 }

--- a/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
+++ b/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
@@ -32,31 +32,6 @@ public class SyncServiceTests
         SyncService.ClearInMemoryPreferences();
     }
 
-    [Fact]
-    public async Task PushPhase_ShouldSendPendingPostsAndClearFlag()
-    {
-        var pendingPost = new Post
-        {
-            Id = "post1",
-            RowKey = "post1",
-            PartitionKey = "pk",
-            Title = "Pending",
-            DateModified = DateTime.UtcNow,
-            IsDeleted = false
-        };
-        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync())
-            .ReturnsAsync(new List<Post> { pendingPost });
-        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync())
-            .ReturnsAsync(new List<Note>());
-        _apiClientMock.Setup(c => c.SavePost(It.IsAny<Post>())).ReturnsAsync(true);
-        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
-        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
-
-        await _sut.SyncAsync();
-
-        _apiClientMock.Verify(c => c.SavePost(pendingPost), Times.Once);
-        _localDataServiceMock.Verify(c => c.MarkSyncedAsync("post1", true), Times.Once);
-    }
 
     [Fact]
     public async Task PushPhase_ShouldSendPendingNotesAndClearFlag()
@@ -83,31 +58,6 @@ public class SyncServiceTests
         _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
     }
 
-    [Fact]
-    public async Task PushPhase_ShouldSendSoftDeletedPostsAsDelete()
-    {
-        var deletedPost = new Post
-        {
-            Id = "post1",
-            RowKey = "post1",
-            PartitionKey = "pk",
-            Title = "Deleted",
-            DateModified = DateTime.UtcNow,
-            IsDeleted = true
-        };
-        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync())
-            .ReturnsAsync(new List<Post> { deletedPost });
-        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync())
-            .ReturnsAsync(new List<Note>());
-        _apiClientMock.Setup(c => c.DeletePost("post1")).ReturnsAsync(true);
-        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
-        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
-
-        await _sut.SyncAsync();
-
-        _apiClientMock.Verify(c => c.DeletePost("post1"), Times.Once);
-        _localDataServiceMock.Verify(c => c.MarkSyncedAsync("post1", true), Times.Once);
-    }
 
     [Fact]
     public async Task PushPhase_ShouldSendSoftDeletedNotesAsDelete()
@@ -277,13 +227,12 @@ public class SyncServiceTests
     [Fact]
     public async Task SyncAsync_ShouldNotRunConcurrently()
     {
-        _localDataServiceMock.Setup(c => c.GetPendingSyncPostsAsync())
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync())
             .Returns(async () =>
             {
                 await Task.Delay(50);
-                return new List<Post>();
+                return new List<Note>();
             });
-        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note>());
         _apiClientMock.Setup(c => c.GetPostsModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<PostL>());
         _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
 
@@ -291,7 +240,7 @@ public class SyncServiceTests
         var task2 = _sut.SyncAsync();
         await Task.WhenAll(task1, task2);
 
-        _localDataServiceMock.Verify(c => c.GetPendingSyncPostsAsync(), Times.Once);
+        _localDataServiceMock.Verify(c => c.GetPendingSyncNotesAsync(), Times.Once);
     }
 
     [Fact]
@@ -403,4 +352,63 @@ public class SyncServiceTests
         _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
         _localDataServiceMock.Verify(c => c.SaveNoteAsync(It.IsAny<Note>(), It.IsAny<bool>()), Times.Never);
     }
+
+    [Fact]
+    public async Task PushPhase_ShouldPropagateNetworkException_WhenGetNoteFailsDueToNetworkError()
+    {
+        var lastSync = new DateTime(2026, 7, 3, 10, 0, 0, DateTimeKind.Utc);
+        SyncService.SetInMemoryPreference("LastSyncTimestamp", lastSync.ToString("O"));
+
+        var pendingNote = new Note
+        {
+            RowKey = "note1",
+            PartitionKey = "pk",
+            Comment = "Local Change",
+            DateModified = DateTime.UtcNow,
+            DateAdded = lastSync.AddHours(-1)
+        };
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note> { pendingNote });
+
+        _apiClientMock.Setup(c => c.GetNote("note1")).ThrowsAsync(new System.Net.Http.HttpRequestException("Connection refused", null, System.Net.HttpStatusCode.ServiceUnavailable));
+
+        Func<Task> act = async () => await _sut.SyncAsync();
+        await act.Should().ThrowAsync<System.Net.Http.HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task PushPhase_ShouldTreatNotFoundHttpRequestExceptionAsDeleted_WhenGetNoteFailsWith404()
+    {
+        var lastSync = new DateTime(2026, 7, 3, 10, 0, 0, DateTimeKind.Utc);
+        SyncService.SetInMemoryPreference("LastSyncTimestamp", lastSync.ToString("O"));
+
+        var pendingNote = new Note
+        {
+            RowKey = "note1",
+            PartitionKey = "pk",
+            Comment = "Local Change",
+            DateModified = DateTime.UtcNow,
+            DateAdded = lastSync.AddHours(-1)
+        };
+        _localDataServiceMock.Setup(c => c.GetPendingSyncNotesAsync()).ReturnsAsync(new List<Note> { pendingNote });
+
+        _apiClientMock.Setup(c => c.GetNote("note1")).ThrowsAsync(new System.Net.Http.HttpRequestException("Not found", null, System.Net.HttpStatusCode.NotFound));
+        _apiClientMock.Setup(c => c.UpdateNote(It.IsAny<Note>())).ReturnsAsync(true);
+
+        _apiClientMock.Setup(c => c.GetPostsModifiedAfter(DateTime.MinValue)).ReturnsAsync(new List<PostL>());
+        _apiClientMock.Setup(c => c.GetNotesModifiedAfter(It.IsAny<DateTime>())).ReturnsAsync(new List<Note>());
+
+        string? conflictMessage = null;
+        _sut.ConflictDetected += (sender, args) =>
+        {
+            conflictMessage = args.Message;
+        };
+
+        await _sut.SyncAsync();
+
+        conflictMessage.Should().NotBeNull();
+        conflictMessage.Should().Contain("deleted online");
+        _apiClientMock.Verify(c => c.UpdateNote(pendingNote), Times.Once);
+        _localDataServiceMock.Verify(c => c.MarkSyncedAsync("note1", false), Times.Once);
+    }
 }
+

--- a/src/NoteBookmark.MauiApp/Data/ISyncApiClient.cs
+++ b/src/NoteBookmark.MauiApp/Data/ISyncApiClient.cs
@@ -15,5 +15,6 @@ public interface ISyncApiClient
     Task<bool> SavePost(Post post);
     Task<bool> DeletePost(string id);
     Task<bool> UpdateNote(Note note);
+    Task<bool> CreateNote(Note note);
     Task<bool> DeleteNote(string rowKey);
 }

--- a/src/NoteBookmark.MauiApp/Data/LocalModels.cs
+++ b/src/NoteBookmark.MauiApp/Data/LocalModels.cs
@@ -95,6 +95,7 @@ public class LocalNote
     // Sync fields
     public bool IsPendingSync { get; set; }
     public bool IsDeleted { get; set; }
+    public bool CreatedOffline { get; set; }
 
     public Note ToDomain() => new Note
     {
@@ -106,7 +107,8 @@ public class LocalNote
         Tags = Tags,
         PostId = PostId,
         Category = Category,
-        IsDeleted = IsDeleted
+        IsDeleted = IsDeleted,
+        CreatedOffline = CreatedOffline
     };
 
     public static LocalNote FromDomain(Note note, bool isPendingSync = false, bool isDeleted = false) => new LocalNote
@@ -120,7 +122,8 @@ public class LocalNote
         PostId = note.PostId,
         Category = note.Category,
         IsPendingSync = isPendingSync,
-        IsDeleted = isDeleted
+        IsDeleted = isDeleted,
+        CreatedOffline = note.CreatedOffline
     };
 }
 

--- a/src/NoteBookmark.MauiApp/Data/OfflineDataService.cs
+++ b/src/NoteBookmark.MauiApp/Data/OfflineDataService.cs
@@ -102,6 +102,7 @@ public class OfflineDataService(PostNoteClient apiClient, ILocalDataService loca
         {
             var settings = await localDataService.GetSettingsAsync();
             note.PartitionKey = settings?.ReadingNotesCounter ?? note.PartitionKey;
+            note.CreatedOffline = true;
             await localDataService.SaveNoteAsync(note, isPendingSync: true);
         }
     }

--- a/src/NoteBookmark.MauiApp/Data/OfflineDataService.cs
+++ b/src/NoteBookmark.MauiApp/Data/OfflineDataService.cs
@@ -260,4 +260,5 @@ public class OfflineDataService(PostNoteClient apiClient, ILocalDataService loca
     public Task<bool> SaveReadingNotesMarkdown(string markdown, string number) => apiClient.SaveReadingNotesMarkdown(markdown, number);
 
     public Task SyncAsync() => syncService.SyncAsync();
+    public bool IsOffline => connectivity.NetworkAccess != NetworkAccess.Internet;
 }

--- a/src/NoteBookmark.MauiApp/Data/OfflineDataService.cs
+++ b/src/NoteBookmark.MauiApp/Data/OfflineDataService.cs
@@ -17,6 +17,7 @@ public class OfflineDataService(PostNoteClient apiClient, ILocalDataService loca
         if (IsOnline)
         {
             var posts = await apiClient.GetUnreadPosts();
+            await MergeLocalNotesIntoRemotePosts(posts);
             return posts;
         }
         else
@@ -49,6 +50,7 @@ public class OfflineDataService(PostNoteClient apiClient, ILocalDataService loca
         if (IsOnline)
         {
             var posts = await apiClient.GetReadPosts();
+            await MergeLocalNotesIntoRemotePosts(posts);
             return posts;
         }
         else
@@ -262,4 +264,26 @@ public class OfflineDataService(PostNoteClient apiClient, ILocalDataService loca
 
     public Task SyncAsync() => syncService.SyncAsync();
     public bool IsOffline => connectivity.NetworkAccess != NetworkAccess.Internet;
+
+    private async Task MergeLocalNotesIntoRemotePosts(List<PostL> remotePosts)
+    {
+        if (remotePosts == null || !remotePosts.Any()) return;
+
+        var localNotes = await localDataService.GetNotesAsync();
+        if (localNotes == null || !localNotes.Any()) return;
+
+        var localNotesByPostId = localNotes
+            .GroupBy(n => n.PostId!)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        foreach (var post in remotePosts)
+        {
+            var id = post.Id ?? post.RowKey;
+            if (localNotesByPostId.TryGetValue(id, out var localNote))
+            {
+                post.Note = localNote.Comment;
+                post.NoteId = localNote.RowKey;
+            }
+        }
+    }
 }

--- a/src/NoteBookmark.MauiApp/Data/OfflineDataService.cs
+++ b/src/NoteBookmark.MauiApp/Data/OfflineDataService.cs
@@ -8,7 +8,7 @@ using NoteBookmark.SharedUI;
 
 namespace NoteBookmark.MauiApp.Data;
 
-public class OfflineDataService(PostNoteClient apiClient, ILocalDataService localDataService, IConnectivity connectivity) : IDataService
+public class OfflineDataService(PostNoteClient apiClient, ILocalDataService localDataService, IConnectivity connectivity, ISyncService syncService) : IDataService
 {
     private bool IsOnline => connectivity.NetworkAccess == NetworkAccess.Internet;
 
@@ -258,4 +258,6 @@ public class OfflineDataService(PostNoteClient apiClient, ILocalDataService loca
     }
 
     public Task<bool> SaveReadingNotesMarkdown(string markdown, string number) => apiClient.SaveReadingNotesMarkdown(markdown, number);
+
+    public Task SyncAsync() => syncService.SyncAsync();
 }

--- a/src/NoteBookmark.MauiApp/Data/SyncApiClient.cs
+++ b/src/NoteBookmark.MauiApp/Data/SyncApiClient.cs
@@ -18,15 +18,8 @@ public class SyncApiClient(PostNoteClient client) : ISyncApiClient
     public Task<bool> UpdateNote(Note note) => client.UpdateNote(note);
     public async Task<bool> CreateNote(Note note)
     {
-        try
-        {
-            await client.CreateNote(note);
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
+        await client.CreateNote(note);
+        return true;
     }
     public Task<bool> DeleteNote(string rowKey) => client.DeleteNote(rowKey);
 }

--- a/src/NoteBookmark.MauiApp/Data/SyncApiClient.cs
+++ b/src/NoteBookmark.MauiApp/Data/SyncApiClient.cs
@@ -16,5 +16,17 @@ public class SyncApiClient(PostNoteClient client) : ISyncApiClient
     public Task<bool> SavePost(Post post) => client.SavePost(post);
     public Task<bool> DeletePost(string id) => client.DeletePost(id);
     public Task<bool> UpdateNote(Note note) => client.UpdateNote(note);
+    public async Task<bool> CreateNote(Note note)
+    {
+        try
+        {
+            await client.CreateNote(note);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
     public Task<bool> DeleteNote(string rowKey) => client.DeleteNote(rowKey);
 }

--- a/src/NoteBookmark.MauiApp/Data/SyncService.cs
+++ b/src/NoteBookmark.MauiApp/Data/SyncService.cs
@@ -65,39 +65,43 @@ public class SyncService(
             
             // Conflict Detection
             Note? remoteNote = null;
-            try
-            {
-                remoteNote = await apiClient.GetNote(id);
-            }
-            catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
-            {
-                remoteNote = null;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to retrieve remote note {RowKey} due to network/server error. Aborting push.", id);
-                throw;
-            }
-
             bool hasConflict = false;
-            if (remoteNote is not null)
+
+            if (!note.CreatedOffline)
             {
-                // Remote note exists. Check if it was modified since the last sync.
-                if (lastSync.HasValue && remoteNote.DateModified > lastSync.Value)
+                try
                 {
-                    hasConflict = true;
+                    remoteNote = await apiClient.GetNote(id);
                 }
-            }
-            else
-            {
-                // Remote note is null. Was it deleted on the server or is it a new local note created offline?
-                if (lastSync.HasValue && note.DateAdded <= lastSync.Value)
+                catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
-                    // It existed at the last sync, but now it's gone from the server -> deleted online.
-                    // If we also deleted it locally, there is no conflict.
-                    if (!note.IsDeleted)
+                    remoteNote = null;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to retrieve remote note {RowKey} due to network/server error. Aborting push.", id);
+                    throw;
+                }
+
+                if (remoteNote is not null)
+                {
+                    // Remote note exists. Check if it was modified since the last sync.
+                    if (lastSync.HasValue && remoteNote.DateModified > lastSync.Value)
                     {
                         hasConflict = true;
+                    }
+                }
+                else
+                {
+                    // Remote note is null. Was it deleted on the server or is it a new local note created offline?
+                    if (lastSync.HasValue && note.DateAdded <= lastSync.Value)
+                    {
+                        // It existed at the last sync, but now it's gone from the server -> deleted online.
+                        // If we also deleted it locally, there is no conflict.
+                        if (!note.IsDeleted)
+                        {
+                            hasConflict = true;
+                        }
                     }
                 }
             }
@@ -131,6 +135,8 @@ public class SyncService(
 
                 if (success)
                 {
+                    note.CreatedOffline = false;
+                    await localDataService.SaveNoteAsync(note, isPendingSync: false);
                     await localDataService.MarkSyncedAsync(id, isPost: false);
                 }
                 else
@@ -155,6 +161,8 @@ public class SyncService(
 
                 if (success)
                 {
+                    note.CreatedOffline = false;
+                    await localDataService.SaveNoteAsync(note, isPendingSync: false);
                     await localDataService.MarkSyncedAsync(id, isPost: false);
                 }
                 else

--- a/src/NoteBookmark.MauiApp/Data/SyncService.cs
+++ b/src/NoteBookmark.MauiApp/Data/SyncService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NoteBookmark.Domain;
@@ -68,9 +69,14 @@ public class SyncService(
             {
                 remoteNote = await apiClient.GetNote(id);
             }
+            catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                remoteNote = null;
+            }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "Failed to retrieve remote note {RowKey} for conflict check.", id);
+                logger.LogError(ex, "Failed to retrieve remote note {RowKey} due to network/server error. Aborting push.", id);
+                throw;
             }
 
             bool hasConflict = false;
@@ -103,8 +109,10 @@ public class SyncService(
                     id, remoteNote?.DateModified, note.DateModified, lastSync);
 
                 var message = remoteNote is not null 
-                    ? $"Sync conflict: Comment was modified online. Local edits saved to server, overwriting remote changes." 
-                    : $"Sync conflict: Comment was deleted online. Local comment has been recreated on server.";
+                    ? (note.IsDeleted
+                        ? "Sync conflict: Comment was modified online but deleted locally. Deletion propagated to server."
+                        : "Sync conflict: Comment was modified online. Local edits saved to server, overwriting remote changes.")
+                    : "Sync conflict: Comment was deleted online. Local comment has been recreated on server.";
                 
                 ConflictDetected?.Invoke(this, new SyncConflictEventArgs(message));
 
@@ -149,31 +157,6 @@ public class SyncService(
                 {
                     logger.LogError("Failed to push comment {RowKey} to server.", id);
                 }
-            }
-        }
-
-        // Push posts (if any pending)
-        var pendingPosts = await localDataService.GetPendingSyncPostsAsync();
-        foreach (var post in pendingPosts)
-        {
-            var id = post.Id ?? post.RowKey;
-            bool success;
-            if (post.IsDeleted)
-            {
-                success = await apiClient.DeletePost(id);
-            }
-            else
-            {
-                success = await apiClient.SavePost(post);
-            }
-
-            if (success)
-            {
-                await localDataService.MarkSyncedAsync(id, isPost: true);
-            }
-            else
-            {
-                logger.LogError("Failed to push post {Id} to server.", id);
             }
         }
     }

--- a/src/NoteBookmark.MauiApp/Data/SyncService.cs
+++ b/src/NoteBookmark.MauiApp/Data/SyncService.cs
@@ -124,7 +124,9 @@ public class SyncService(
                 }
                 else
                 {
-                    success = await apiClient.UpdateNote(note);
+                    success = remoteNote is null 
+                        ? await apiClient.CreateNote(note) 
+                        : await apiClient.UpdateNote(note);
                 }
 
                 if (success)
@@ -146,7 +148,9 @@ public class SyncService(
                 }
                 else
                 {
-                    success = await apiClient.UpdateNote(note);
+                    success = remoteNote is null 
+                        ? await apiClient.CreateNote(note) 
+                        : await apiClient.UpdateNote(note);
                 }
 
                 if (success)

--- a/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
+++ b/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
@@ -17,6 +17,7 @@
     <FluentStack Orientation="Orientation.Horizontal">
         <FluentButton OnClick="AddNewPost" IconEnd="@(new Icons.Regular.Size20.Add())" Title="Add new post"></FluentButton>
         <FluentTextField @bind-Value="newPostUrl" Placeholder="Enter URL" style="width: 100%;"/>
+        <FluentButton OnClick="SyncNow" IconStart="@(new Icons.Regular.Size20.ArrowSync())" Loading="isSyncing" Title="Sync posts and comments">Sync</FluentButton>
     </FluentStack>
     <FluentSwitch ValueChanged="OnShowReadChanged" Label="Show">
         <span slot="checked-message">Read Only</span>
@@ -220,6 +221,29 @@
         if (string.IsNullOrWhiteSpace(titleFilter))
         {
             titleFilter = string.Empty;
+        }
+    }
+
+    private bool isSyncing = false;
+
+    private async Task SyncNow()
+    {
+        if (isSyncing) return;
+        isSyncing = true;
+        try
+        {
+            toastService.ShowInfo("Synchronization started...");
+            await client.SyncAsync();
+            toastService.ShowSuccess("Synchronization completed successfully!");
+            await LoadPosts();
+        }
+        catch (Exception ex)
+        {
+            toastService.ShowError($"Synchronization failed: {ex.Message}");
+        }
+        finally
+        {
+            isSyncing = false;
         }
     }
 }

--- a/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
+++ b/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
@@ -15,8 +15,8 @@
 
 <FluentStack Orientation="Orientation.Vertical">
     <FluentStack Orientation="Orientation.Horizontal">
-        <FluentButton OnClick="AddNewPost" IconEnd="@(new Icons.Regular.Size20.Add())" Title="Add new post"></FluentButton>
-        <FluentTextField @bind-Value="newPostUrl" Placeholder="Enter URL" style="width: 100%;"/>
+        <FluentButton OnClick="AddNewPost" Disabled="@client.IsOffline" IconEnd="@(new Icons.Regular.Size20.Add())" Title="Add new post"></FluentButton>
+        <FluentTextField @bind-Value="newPostUrl" Disabled="@client.IsOffline" Placeholder="@(client.IsOffline ? "Cannot add posts offline" : "Enter URL")" style="width: 100%;"/>
         <FluentButton OnClick="SyncNow" IconStart="@(new Icons.Regular.Size20.ArrowSync())" Loading="isSyncing" Title="Sync posts and comments">Sync</FluentButton>
     </FluentStack>
     <FluentSwitch ValueChanged="OnShowReadChanged" Label="Show">

--- a/src/NoteBookmark.SharedUI/IDataService.cs
+++ b/src/NoteBookmark.SharedUI/IDataService.cs
@@ -24,4 +24,5 @@ public interface IDataService
     Task<bool> DeletePost(string id);
     Task<bool> SaveReadingNotesMarkdown(string markdown, string number);
     Task SyncAsync();
+    bool IsOffline { get; }
 }

--- a/src/NoteBookmark.SharedUI/IDataService.cs
+++ b/src/NoteBookmark.SharedUI/IDataService.cs
@@ -23,4 +23,5 @@ public interface IDataService
     Task<bool> ExtractPostDetailsAndSave(string url);
     Task<bool> DeletePost(string id);
     Task<bool> SaveReadingNotesMarkdown(string markdown, string number);
+    Task SyncAsync();
 }

--- a/src/NoteBookmark.SharedUI/PostNoteClient.cs
+++ b/src/NoteBookmark.SharedUI/PostNoteClient.cs
@@ -188,4 +188,6 @@ public class PostNoteClient(HttpClient httpClient) : IDataService
         var notes = await httpClient.GetFromJsonAsync<List<Note>>($"api/notes?modifiedAfter={encoded}");
         return notes ?? new List<Note>();
     }
+
+    public Task SyncAsync() => Task.CompletedTask;
 }

--- a/src/NoteBookmark.SharedUI/PostNoteClient.cs
+++ b/src/NoteBookmark.SharedUI/PostNoteClient.cs
@@ -184,10 +184,18 @@ public class PostNoteClient(HttpClient httpClient) : IDataService
 
     public async Task<List<Note>> GetNotesModifiedAfter(DateTime modifiedAfter)
     {
-        var encoded = System.Web.HttpUtility.UrlEncode(modifiedAfter.ToUniversalTime().ToString("O"));
-        var notes = await httpClient.GetFromJsonAsync<List<Note>>($"api/notes?modifiedAfter={encoded}");
-        return notes ?? new List<Note>();
+        try
+        {
+            var encoded = System.Web.HttpUtility.UrlEncode(modifiedAfter.ToUniversalTime().ToString("O"));
+            var notes = await httpClient.GetFromJsonAsync<List<Note>>($"api/notes?modifiedAfter={encoded}");
+            return notes ?? new List<Note>();
+        }
+        catch (System.Net.Http.HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return new List<Note>();
+        }
     }
 
     public Task SyncAsync() => Task.CompletedTask;
+    public bool IsOffline => false;
 }

--- a/src/NoteBookmark.SharedUI/PostNoteClient.cs
+++ b/src/NoteBookmark.SharedUI/PostNoteClient.cs
@@ -29,7 +29,11 @@ public class PostNoteClient(HttpClient httpClient) : IDataService
         var rnCounter = await httpClient.GetStringAsync("api/settings/GetNextReadingNotesCounter");
         note.PartitionKey = rnCounter;
         var response = await httpClient.PostAsJsonAsync("api/notes/note", note);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            throw new HttpRequestException($"Server returned Bad Request: {errorContent}", null, response.StatusCode);
+        }
     }
 
     public async Task<Note?> GetNote(string noteId)


### PR DESCRIPTION
This PR reworks the offline synchronization service, resolves disappearing offline notes by using CreateNote (POST) when appropriate,  adds a force Sync button to the posts age, disables post adding when offline, and resolves the Azure Tables SDK DateTime kind  exception.