### PR TITLE
fix(summaryeditor): prevent IndexOutOfRangeException on missing tags

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/NoteBookmark.BlazorApp.Tests/Tests/PostNoteClientTests.cs
+++ b/src/NoteBookmark.BlazorApp.Tests/Tests/PostNoteClientTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NoteBookmark.Domain;
+using NoteBookmark.SharedUI;
+using Xunit;
+
+namespace NoteBookmark.BlazorApp.Tests.Tests;
+
+public class PostNoteClientTests
+{
+    private class TestHttpMessageHandler : HttpMessageHandler
+    {
+        public Func<HttpRequestMessage, HttpResponseMessage> Handler { get; set; } = null!;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Handler(request));
+        }
+    }
+
+    [Fact]
+    public async Task CreateReadingNotes_WithNullTags_ShouldNotThrowAndShouldFallbackToMiscellaneous()
+    {
+        // Arrange
+        var handler = new TestHttpMessageHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var postNoteClient = new PostNoteClient(client);
+
+        var notesList = new List<ReadingNote>
+        {
+            new ReadingNote { Title = "Note 1", Tags = null, Category = null }
+        };
+
+        handler.Handler = (req) =>
+        {
+            if (req.RequestUri!.PathAndQuery.Contains("GetNextReadingNotesCounter"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("708")
+                };
+            }
+            if (req.RequestUri!.PathAndQuery.Contains("GetNotesForSummary/708"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(notesList), System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        };
+
+        // Act
+        var result = await postNoteClient.CreateReadingNotes();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Notes.Should().ContainKey("Miscellaneous");
+        result.Notes["Miscellaneous"].Should().HaveCount(1);
+        result.Notes["Miscellaneous"][0].Title.Should().Be("Note 1");
+    }
+
+    [Fact]
+    public async Task CreateReadingNotes_WithEmptyTags_ShouldNotThrowAndShouldFallbackToMiscellaneous()
+    {
+        // Arrange
+        var handler = new TestHttpMessageHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var postNoteClient = new PostNoteClient(client);
+
+        var notesList = new List<ReadingNote>
+        {
+            new ReadingNote { Title = "Note 2", Tags = "", Category = null }
+        };
+
+        handler.Handler = (req) =>
+        {
+            if (req.RequestUri!.PathAndQuery.Contains("GetNextReadingNotesCounter"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("708")
+                };
+            }
+            if (req.RequestUri!.PathAndQuery.Contains("GetNotesForSummary/708"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(notesList), System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        };
+
+        // Act
+        var result = await postNoteClient.CreateReadingNotes();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Notes.Should().ContainKey("Miscellaneous");
+        result.Notes["Miscellaneous"].Should().HaveCount(1);
+        result.Notes["Miscellaneous"][0].Title.Should().Be("Note 2");
+    }
+
+    [Fact]
+    public async Task CreateReadingNotes_WithValidTags_ShouldGroupByCategory()
+    {
+        // Arrange
+        var handler = new TestHttpMessageHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var postNoteClient = new PostNoteClient(client);
+
+        var notesList = new List<ReadingNote>
+        {
+            new ReadingNote { Title = "Note 3", Tags = "cloud,dev", Category = null }
+        };
+
+        handler.Handler = (req) =>
+        {
+            if (req.RequestUri!.PathAndQuery.Contains("GetNextReadingNotesCounter"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("708")
+                };
+            }
+            if (req.RequestUri!.PathAndQuery.Contains("GetNotesForSummary/708"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(notesList), System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        };
+
+        // Act
+        var result = await postNoteClient.CreateReadingNotes();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Notes.Should().ContainKey("Cloud");
+        result.Notes["Cloud"].Should().HaveCount(1);
+        result.Notes["Cloud"][0].Title.Should().Be("Note 3");
+    }
+}

--- a/src/NoteBookmark.MauiApp/NoteBookmark.MauiApp.csproj
+++ b/src/NoteBookmark.MauiApp/NoteBookmark.MauiApp.csproj
@@ -44,9 +44,9 @@
         <ApplicationId>c5m.notebookmark.mauiapp</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.3.0</ApplicationDisplayVersion>
-        <ApplicationVersion>3</ApplicationVersion>
-        <Version>1.3.0</Version>
+        <ApplicationDisplayVersion>1.3.1</ApplicationDisplayVersion>
+        <ApplicationVersion>4</ApplicationVersion>
+        <Version>1.3.1</Version>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>

--- a/src/NoteBookmark.SharedUI/PostNoteClient.cs
+++ b/src/NoteBookmark.SharedUI/PostNoteClient.cs
@@ -91,7 +91,7 @@ public class PostNoteClient(HttpClient httpClient) : IDataService
             
             if (string.IsNullOrEmpty(note.Category))
             {
-                note.Category = NoteCategories.GetCategory(tags[0]);
+                note.Category = NoteCategories.GetCategory(tags.Length > 0 ? tags[0] : null);
             }
 
             string category = note.Category;


### PR DESCRIPTION
Fixes a crash when navigating to summaryeditor by checking if tags are present before indexing. Also added unit tests in PostNoteClientTests.cs.