### PR TITLE
fix(#173): use Id ?? RowKey for checking and opening offline post HTML

### DIFF
--- a/src/NoteBookmark.BlazorApp.Tests/Tests/PostsTests.cs
+++ b/src/NoteBookmark.BlazorApp.Tests/Tests/PostsTests.cs
@@ -127,3 +127,36 @@ public sealed class PostsTests : BunitContext
         cut.Markup.Should().Contain("Nothing to see here");
     }
 }
+
+public sealed class PostsHtmlCacheTests : BunitContext
+{
+    [Fact]
+    public void Posts_ChecksHtmlCacheWithPostId_WhenIdIsPresent()
+    {
+        this.AddFluentUI();
+        this.AddAuthorization().SetAuthorized("testuser");
+
+        var dataServiceMock = new Mock<IDataService>();
+        dataServiceMock.Setup(s => s.GetUnreadPosts()).ReturnsAsync([
+            new PostL { PartitionKey = "p", RowKey = "row-key-456", Id = "custom-id-123", Title = "Post With Id", Url = "https://example.com/id", Date_published = "2025-01-15T00:00:00", is_read = false }
+        ]);
+        dataServiceMock.Setup(s => s.GetReadPosts()).ReturnsAsync([]);
+        dataServiceMock.Setup(s => s.SyncAsync()).Returns(Task.CompletedTask);
+        dataServiceMock.SetupGet(s => s.IsOffline).Returns(false);
+        dataServiceMock.SetupGet(s => s.CanSync).Returns(false);
+
+        var htmlCacheMock = new Mock<ILocalHtmlCache>();
+        htmlCacheMock.Setup(c => c.IsHtmlCached("custom-id-123")).Returns(true);
+
+        Services.AddSingleton(dataServiceMock.Object);
+        Services.AddSingleton(new Mock<IToastService>().Object);
+        Services.AddSingleton(new Mock<IDialogService>().Object);
+        Services.AddSingleton(htmlCacheMock.Object);
+
+        var cut = Render<Posts>();
+
+        htmlCacheMock.Verify(c => c.IsHtmlCached("custom-id-123"), Times.Once);
+        cut.Markup.Should().Contain("Read post");
+    }
+}
+

--- a/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
+++ b/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
@@ -42,9 +42,9 @@
             {
                 <FluentButton OnClick="@(() => EditNoteForPost(context!.NoteId))" IconEnd="@(new Icons.Filled.Size20.NoteEdit())" />
             }
-            @if (localHtmlCache.IsHtmlCached(context!.RowKey))
+            @if (localHtmlCache.IsHtmlCached(context!.Id ?? context!.RowKey))
             {
-                <FluentButton OnClick="@(() => ReadPost(context!.RowKey))" IconEnd="@(new Icons.Regular.Size20.Book())" Title="Read post" />
+                <FluentButton OnClick="@(() => ReadPost(context!.Id ?? context!.RowKey))" IconEnd="@(new Icons.Regular.Size20.Book())" Title="Read post" />
             }
         </TemplateColumn>
         <PropertyColumn Title="Title" Property="@(c => c!.Title)" Sortable="true"  Filtered="!string.IsNullOrWhiteSpace(titleFilter)" >


### PR DESCRIPTION
Fixes #173 by ensuring offline HTML cache checks and reader navigation use \context!.Id ?? context!.RowKey\.