### PR TITLE
feat: improve sync html download, always display read post button, and remove ILocalHtmlCache

### DIFF
--- a/src/NoteBookmark.Api.Tests/Endpoints/PostExtractionTests.cs
+++ b/src/NoteBookmark.Api.Tests/Endpoints/PostExtractionTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NoteBookmark.Api.Tests.Fixtures;
+using NoteBookmark.Domain;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+using Azure.Storage.Blobs;
+
+namespace NoteBookmark.Api.Tests.Endpoints;
+
+public class PostExtractionTests : IClassFixture<NoteBookmarkApiTestFactory>
+{
+    private readonly NoteBookmarkApiTestFactory _factory;
+    private readonly HttpClient _client;
+
+    public PostExtractionTests(NoteBookmarkApiTestFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ExtractPostDetails_TriggersBackgroundWorkerAndSavesHtmlToBlobStorage()
+    {
+        // Arrange
+        var url = "https://example.com/blog/test-post-" + Guid.NewGuid();
+        var extractRequest = new
+        {
+            url = url,
+            tags = "test",
+            category = "Test"
+        };
+
+        // Act - Call the API to extract metadata and save the post
+        var response = await _client.PostAsJsonAsync("/api/posts/extractPostDetails", extractRequest);
+
+        // Assert API response is OK
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var post = await response.Content.ReadFromJsonAsync<Post>();
+        post.Should().NotBeNull();
+        var postId = post!.Id ?? post.RowKey;
+        postId.Should().NotBeNullOrEmpty();
+
+        // Since the extraction happens asynchronously in a BackgroundWorker,
+        // we poll the blob storage for a short time to verify the file was created.
+        var blobServiceClient = _factory.Services.GetRequiredService<BlobServiceClient>();
+        var containerClient = blobServiceClient.GetBlobContainerClient("cleanedposts");
+        var blobClient = containerClient.GetBlobClient($"{postId}.html");
+
+        // Wait up to 5 seconds for the background worker to process
+        bool blobExists = false;
+        for (int i = 0; i < 25; i++)
+        {
+            if (await blobClient.ExistsAsync())
+            {
+                blobExists = true;
+                break;
+            }
+            await Task.Delay(200);
+        }
+
+        blobExists.Should().BeTrue("HTML content should be processed by the background worker and saved to blob storage");
+
+        // Verify the content saved matches the fake content
+        var downloadResult = await blobClient.DownloadContentAsync();
+        var content = downloadResult.Value.Content.ToString();
+        content.Should().Contain(url);
+    }
+}

--- a/src/NoteBookmark.Api.Tests/Fixtures/FakePostParserClient.cs
+++ b/src/NoteBookmark.Api.Tests/Fixtures/FakePostParserClient.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NoteBookmark.Api.Tests.Fixtures;
+
+public class FakePostParserClient : IPostParserClient
+{
+    public Task<string?> ExtractContentAsync(string url, CancellationToken cancellationToken = default)
+    {
+        // Return a mock HTML snippet for testing
+        return Task.FromResult<string?>($"<div>Extracted HTML content for {url}</div>");
+    }
+}

--- a/src/NoteBookmark.Api.Tests/Fixtures/NoteBookmarkApiTestFactory.cs
+++ b/src/NoteBookmark.Api.Tests/Fixtures/NoteBookmarkApiTestFactory.cs
@@ -34,6 +34,9 @@ public class NoteBookmarkApiTestFactory : WebApplicationFactory<Program>, IAsync
                 services.AddSingleton(new TableServiceClient(connectionString));
                 services.AddSingleton(new BlobServiceClient(connectionString));
             }
+
+            // Register FakePostParserClient for integration tests
+            services.AddSingleton<NoteBookmark.Api.IPostParserClient, FakePostParserClient>();
         });
     }
 

--- a/src/NoteBookmark.Api/IPostParserClient.cs
+++ b/src/NoteBookmark.Api/IPostParserClient.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NoteBookmark.Api;
+
+public interface IPostParserClient
+{
+    Task<string?> ExtractContentAsync(string url, CancellationToken cancellationToken = default);
+}

--- a/src/NoteBookmark.Api/PostEndpoints.cs
+++ b/src/NoteBookmark.Api/PostEndpoints.cs
@@ -94,7 +94,11 @@ public static class PostEndpoints
 		}
 		return TypedResults.BadRequest();
 	}
-	static async Task<Results<Ok<Post>, BadRequest>> ExtractPostDetails(ExtractPostRequest request, TableServiceClient tblClient, BlobServiceClient blobClient)
+	static async Task<Results<Ok<Post>, BadRequest>> ExtractPostDetails(
+		ExtractPostRequest request,
+		TableServiceClient tblClient,
+		BlobServiceClient blobClient,
+		PostExtractionQueue queue)
 	{
 		var dataStorageService = new DataStorageService(tblClient, blobClient);
 
@@ -105,6 +109,10 @@ public static class PostEndpoints
 			if (post != null)
 			{
 				dataStorageService.SavePost(post);
+				
+				// Queue background HTML extraction task
+				queue.QueueBackgroundWorkItem(new ExtractionTask(post.Id ?? post.RowKey, post.Url ?? decodeUrl));
+
 				return TypedResults.Ok(post);
 			}
 			return TypedResults.BadRequest();

--- a/src/NoteBookmark.Api/PostExtractionBackgroundWorker.cs
+++ b/src/NoteBookmark.Api/PostExtractionBackgroundWorker.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace NoteBookmark.Api;
+
+public class PostExtractionBackgroundWorker : BackgroundService
+{
+    private readonly PostExtractionQueue _queue;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<PostExtractionBackgroundWorker> _logger;
+
+    public PostExtractionBackgroundWorker(
+        PostExtractionQueue queue,
+        IServiceProvider serviceProvider,
+        ILogger<PostExtractionBackgroundWorker> logger)
+    {
+        _queue = queue;
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Post Extraction Background Worker started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var task = await _queue.DequeueAsync(stoppingToken);
+                _logger.LogInformation("Processing extraction for Post: {PostId}, URL: {Url}", task.PostId, task.Url);
+
+                await ProcessExtractionAsync(task, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Normal shutdown
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred executing background extraction task.");
+            }
+        }
+
+        _logger.LogInformation("Post Extraction Background Worker stopped.");
+    }
+
+    private async Task ProcessExtractionAsync(ExtractionTask task, CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var parserClient = scope.ServiceProvider.GetRequiredService<IPostParserClient>();
+        var blobServiceClient = scope.ServiceProvider.GetRequiredService<BlobServiceClient>();
+
+        try
+        {
+            var content = await parserClient.ExtractContentAsync(task.Url, cancellationToken);
+            if (string.IsNullOrEmpty(content))
+            {
+                _logger.LogWarning("No content returned for URL: {Url}. Skipping blob upload.", task.Url);
+                return;
+            }
+
+            var containerClient = blobServiceClient.GetBlobContainerClient("cleanedposts");
+            await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+            var blobClient = containerClient.GetBlobClient($"{task.PostId}.html");
+            
+            byte[] contentBytes = Encoding.UTF8.GetBytes(content);
+            using var stream = new MemoryStream(contentBytes);
+            
+            await blobClient.UploadAsync(stream, overwrite: true, cancellationToken: cancellationToken);
+            _logger.LogInformation("Successfully saved extracted HTML for Post {PostId} to Blob Storage.", task.PostId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process extraction for Post {PostId} / URL: {Url}", task.PostId, task.Url);
+        }
+    }
+}

--- a/src/NoteBookmark.Api/PostExtractionQueue.cs
+++ b/src/NoteBookmark.Api/PostExtractionQueue.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace NoteBookmark.Api;
+
+public record ExtractionTask(string PostId, string Url);
+
+public class PostExtractionQueue
+{
+    private readonly Channel<ExtractionTask> _queue;
+
+    public PostExtractionQueue()
+    {
+        // Unbounded channel is simple and suitable for this task queue.
+        _queue = Channel.CreateUnbounded<ExtractionTask>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+    }
+
+    public void QueueBackgroundWorkItem(ExtractionTask task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        _queue.Writer.TryWrite(task);
+    }
+
+    public async ValueTask<ExtractionTask> DequeueAsync(CancellationToken cancellationToken)
+    {
+        return await _queue.Reader.ReadAsync(cancellationToken);
+    }
+}

--- a/src/NoteBookmark.Api/PostParserClient.cs
+++ b/src/NoteBookmark.Api/PostParserClient.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace NoteBookmark.Api;
+
+public class PostParserClient : IPostParserClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<PostParserClient> _logger;
+
+    public PostParserClient(HttpClient httpClient, ILogger<PostParserClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        // Configure base address or default headers if needed, but since URL is fully specified we can just configure it or call it directly.
+        if (_httpClient.BaseAddress == null)
+        {
+            _httpClient.BaseAddress = new Uri("https://azpostlight-parser.azurewebsites.net/");
+        }
+    }
+
+    public async Task<string?> ExtractContentAsync(string url, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("Calling parser API for URL: {Url}", url);
+            var requestBody = new { url = url };
+            var response = await _httpClient.PostAsJsonAsync("parser", requestBody, cancellationToken);
+            
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Parser API returned error status: {StatusCode}", response.StatusCode);
+                return null;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<ParserResponse>(cancellationToken: cancellationToken);
+            return result?.Content;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to extract content for URL: {Url}", url);
+            return null;
+        }
+    }
+
+    private class ParserResponse
+    {
+        [JsonPropertyName("content")]
+        public string? Content { get; set; }
+    }
+}

--- a/src/NoteBookmark.Api/Program.cs
+++ b/src/NoteBookmark.Api/Program.cs
@@ -15,6 +15,11 @@ builder.Services.AddSwaggerGen();
 // Register data storage service
 builder.Services.AddScoped<IDataStorageService, DataStorageService>();
 
+// Register background extraction queue and worker
+builder.Services.AddHttpClient<IPostParserClient, PostParserClient>();
+builder.Services.AddSingleton<PostExtractionQueue>();
+builder.Services.AddHostedService<PostExtractionBackgroundWorker>();
+
 // Register AI settings provider
 builder.Services.AddScoped<IAISettingsProvider, AISettingsProvider>();
 

--- a/src/NoteBookmark.BlazorApp.Tests/Tests/PostsTests.cs
+++ b/src/NoteBookmark.BlazorApp.Tests/Tests/PostsTests.cs
@@ -39,7 +39,6 @@ public sealed class PostsTests : BunitContext
         Services.AddSingleton(_dataServiceMock.Object);
         Services.AddSingleton(new Mock<IToastService>().Object);
         Services.AddSingleton(new Mock<IDialogService>().Object);
-        Services.AddSingleton<ILocalHtmlCache>(new NoteBookmark.BlazorApp.AlwaysAvailableHtmlCache());
     }
 
     [Fact]
@@ -126,36 +125,12 @@ public sealed class PostsTests : BunitContext
 
         cut.Markup.Should().Contain("Nothing to see here");
     }
-}
 
-public sealed class PostsHtmlCacheTests : BunitContext
-{
     [Fact]
-    public void Posts_ChecksHtmlCacheWithPostId_WhenIdIsPresent()
+    public void Posts_ReadPostButton_IsAlwaysRendered()
     {
-        this.AddFluentUI();
-        this.AddAuthorization().SetAuthorized("testuser");
-
-        var dataServiceMock = new Mock<IDataService>();
-        dataServiceMock.Setup(s => s.GetUnreadPosts()).ReturnsAsync([
-            new PostL { PartitionKey = "p", RowKey = "row-key-456", Id = "custom-id-123", Title = "Post With Id", Url = "https://example.com/id", Date_published = "2025-01-15T00:00:00", is_read = false }
-        ]);
-        dataServiceMock.Setup(s => s.GetReadPosts()).ReturnsAsync([]);
-        dataServiceMock.Setup(s => s.SyncAsync()).Returns(Task.CompletedTask);
-        dataServiceMock.SetupGet(s => s.IsOffline).Returns(false);
-        dataServiceMock.SetupGet(s => s.CanSync).Returns(false);
-
-        var htmlCacheMock = new Mock<ILocalHtmlCache>();
-        htmlCacheMock.Setup(c => c.IsHtmlCached("custom-id-123")).Returns(true);
-
-        Services.AddSingleton(dataServiceMock.Object);
-        Services.AddSingleton(new Mock<IToastService>().Object);
-        Services.AddSingleton(new Mock<IDialogService>().Object);
-        Services.AddSingleton(htmlCacheMock.Object);
-
         var cut = Render<Posts>();
 
-        htmlCacheMock.Verify(c => c.IsHtmlCached("custom-id-123"), Times.Once);
         cut.Markup.Should().Contain("Read post");
     }
 }

--- a/src/NoteBookmark.BlazorApp/AlwaysAvailableHtmlCache.cs
+++ b/src/NoteBookmark.BlazorApp/AlwaysAvailableHtmlCache.cs
@@ -1,8 +1,0 @@
-using NoteBookmark.SharedUI;
-
-namespace NoteBookmark.BlazorApp;
-
-public class AlwaysAvailableHtmlCache : ILocalHtmlCache
-{
-    public bool IsHtmlCached(string postId) => true;
-}

--- a/src/NoteBookmark.BlazorApp/Program.cs
+++ b/src/NoteBookmark.BlazorApp/Program.cs
@@ -18,7 +18,6 @@ builder.Services.AddHttpClient<PostNoteClient>(client =>
                 client.BaseAddress = new Uri("https+http://api");
             });
 builder.Services.AddTransient<IDataService>(sp => sp.GetRequiredService<PostNoteClient>());
-builder.Services.AddSingleton<ILocalHtmlCache, NoteBookmark.BlazorApp.AlwaysAvailableHtmlCache>();
 builder.Services.AddScoped<IUrlLauncher, JsUrlLauncher>();
 
 // Register server-side AI settings provider (direct database access, unmasked)

--- a/src/NoteBookmark.MauiApp/Data/LocalHtmlStorageService.cs
+++ b/src/NoteBookmark.MauiApp/Data/LocalHtmlStorageService.cs
@@ -2,16 +2,18 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using NoteBookmark.SharedUI;
 
 namespace NoteBookmark.MauiApp.Data;
 
-public class LocalHtmlStorageService(string baseDirectory) : ILocalHtmlStorageService, ILocalHtmlCache
+public class LocalHtmlStorageService(string baseDirectory) : ILocalHtmlStorageService
 {
     private string FilePath(string postId) => Path.Combine(baseDirectory, $"{postId}.html");
 
     public async Task SavePostHtmlAsync(string postId, string html)
-        => await File.WriteAllTextAsync(FilePath(postId), html);
+    {
+        Directory.CreateDirectory(baseDirectory);
+        await File.WriteAllTextAsync(FilePath(postId), html);
+    }
 
     public async Task<string?> GetPostHtmlAsync(string postId)
     {
@@ -21,8 +23,6 @@ public class LocalHtmlStorageService(string baseDirectory) : ILocalHtmlStorageSe
     }
 
     public bool IsPostHtmlCached(string postId) => File.Exists(FilePath(postId));
-
-    public bool IsHtmlCached(string postId) => IsPostHtmlCached(postId);
 
     public void RemovePostHtml(string postId)
     {

--- a/src/NoteBookmark.MauiApp/MauiProgram.cs
+++ b/src/NoteBookmark.MauiApp/MauiProgram.cs
@@ -39,8 +39,6 @@ public static class MauiProgram
             sp => new NoteBookmark.MauiApp.Data.LocalHtmlStorageService(FileSystem.AppDataDirectory));
         builder.Services.AddSingleton<NoteBookmark.MauiApp.Data.ILocalHtmlStorageService>(
             sp => sp.GetRequiredService<NoteBookmark.MauiApp.Data.LocalHtmlStorageService>());
-        builder.Services.AddSingleton<NoteBookmark.SharedUI.ILocalHtmlCache>(
-            sp => sp.GetRequiredService<NoteBookmark.MauiApp.Data.LocalHtmlStorageService>());
 
         builder.Services.AddTransient<ApiBaseUrlDelegatingHandler>();
         builder.Services.AddHttpClient<NoteBookmark.SharedUI.PostNoteClient>(client => 

--- a/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
+++ b/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
@@ -8,7 +8,6 @@
 @inject IToastService toastService
 @inject IDialogService DialogService
 @inject NavigationManager Navigation
-@inject ILocalHtmlCache localHtmlCache
 @inject IUrlLauncher urlLauncher
 @implements IDisposable
 
@@ -54,10 +53,7 @@
             {
                 <FluentButton OnClick="@(() => EditNoteForPost(context!.NoteId))" IconEnd="@(new Icons.Filled.Size20.NoteEdit())" />
             }
-            @if (localHtmlCache.IsHtmlCached(context!.Id ?? context!.RowKey))
-            {
-                <FluentButton OnClick="@(() => ReadPost(context!.Id ?? context!.RowKey))" IconEnd="@(new Icons.Regular.Size20.Book())" Title="Read post" />
-            }
+            <FluentButton OnClick="@(() => ReadPost(context!.Id ?? context!.RowKey))" IconEnd="@(new Icons.Regular.Size20.Book())" Title="Read post" />
         </TemplateColumn>
         <PropertyColumn Title="Title" Property="@(c => c!.Title)" Sortable="true"  Filtered="!string.IsNullOrWhiteSpace(titleFilter)" >
             <ColumnOptions>

--- a/src/NoteBookmark.SharedUI/ILocalHtmlCache.cs
+++ b/src/NoteBookmark.SharedUI/ILocalHtmlCache.cs
@@ -1,6 +1,0 @@
-namespace NoteBookmark.SharedUI;
-
-public interface ILocalHtmlCache
-{
-    bool IsHtmlCached(string postId);
-}


### PR DESCRIPTION
This PR improves file management for the Android MAUI App: 1. Removes ILocalHtmlCache interface and its registrations since the Read Post button is now always rendered. 2. Modifies Posts.razor to always display the Read Post button. 3. Ensures directory exists when saving HTML files locally in LocalHtmlStorageService.