### PR TITLE
fix(#190): update actions/cache to v5 for Node.js 24 compatibility in OpenCode triage workflow

### DIFF
--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -17,14 +17,34 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: anomalyco/opencode/github@latest
+      - name: Get opencode version
+        id: version
+        run: |
+          VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+          echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
+
+      - name: Cache opencode
+        id: cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.opencode/bin
+          key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
+
+      - name: Install opencode
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Add opencode to PATH
+        run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
+
+      - name: Run opencode
+        run: opencode github run
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          model: opencode/big-pickle
-          use_github_token: true
-          prompt: |
+          MODEL: opencode/big-pickle
+          USE_GITHUB_TOKEN: "true"
+          PROMPT: |
             You are a triage agent. Triaging open GitHub issues in this repo.
 
             1. Use `gh issue list --state open --json number,title,body,labels,createdAt` to list open issues.


### PR DESCRIPTION
Fixes #190

Updates the OpenCode Daily Triage workflow by inlining the opencode action steps and upgrading  to  to run on the Node.js 24 runtime and resolve runner deprecation warnings.