### PR TITLE
Update version to 1.4.2, add sync progress tracking, and reader page controls

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/NoteBookmark.BlazorApp.Tests/Tests/PostReaderTests.cs
+++ b/src/NoteBookmark.BlazorApp.Tests/Tests/PostReaderTests.cs
@@ -34,7 +34,7 @@ public sealed class PostReaderTests : BunitContext
     }
 
     [Fact]
-    public void PostReader_RendersTitleAndContentAndSlider()
+    public void PostReader_RendersTitleAndContentAndSlidersAndBackButtonsAtTopAndBottom()
     {
         var cut = Render<PostReader>(ps => ps.Add(p => p.PostId, "p1"));
 
@@ -44,23 +44,43 @@ public sealed class PostReaderTests : BunitContext
         cut.Markup.Should().Contain("reader-content");
         cut.Markup.Should().Contain("Text size:");
 
-        var slider = cut.FindComponent<FluentSlider<int>>();
-        slider.Instance.Min.Should().Be(8);
-        slider.Instance.Max.Should().Be(56);
+        var sliders = cut.FindComponents<FluentSlider<int>>();
+        sliders.Should().HaveCount(2);
+        sliders[0].Instance.Min.Should().Be(8);
+        sliders[0].Instance.Max.Should().Be(56);
+        sliders[1].Instance.Min.Should().Be(8);
+        sliders[1].Instance.Max.Should().Be(56);
+
+        var backButtons = cut.FindComponents<FluentButton>()
+            .Where(b => b.Instance.Title == "Back to posts")
+            .ToList();
+        backButtons.Should().HaveCount(2);
     }
 
     [Fact]
-    public void PostReader_SliderValueChange_UpdatesContentFontSize()
+    public void PostReader_TopSliderValueChange_UpdatesContentFontSize()
     {
         var cut = Render<PostReader>(ps => ps.Add(p => p.PostId, "p1"));
 
         var contentDivBefore = cut.Find("div.reader-content");
         contentDivBefore.GetAttribute("style").Should().Contain("font-size: 16px;");
 
-        var slider = cut.FindComponent<FluentSlider<int>>();
-        cut.InvokeAsync(() => slider.Instance.ValueChanged.InvokeAsync(24));
+        var sliders = cut.FindComponents<FluentSlider<int>>();
+        cut.InvokeAsync(() => sliders[0].Instance.ValueChanged.InvokeAsync(24));
 
         var contentDivAfter = cut.Find("div.reader-content");
         contentDivAfter.GetAttribute("style").Should().Contain("font-size: 24px;");
+    }
+
+    [Fact]
+    public void PostReader_BottomSliderValueChange_UpdatesContentFontSize()
+    {
+        var cut = Render<PostReader>(ps => ps.Add(p => p.PostId, "p1"));
+
+        var sliders = cut.FindComponents<FluentSlider<int>>();
+        cut.InvokeAsync(() => sliders[1].Instance.ValueChanged.InvokeAsync(20));
+
+        var contentDivAfter = cut.Find("div.reader-content");
+        contentDivAfter.GetAttribute("style").Should().Contain("font-size: 20px;");
     }
 }

--- a/src/NoteBookmark.BlazorApp.Tests/Tests/PostsTests.cs
+++ b/src/NoteBookmark.BlazorApp.Tests/Tests/PostsTests.cs
@@ -133,5 +133,34 @@ public sealed class PostsTests : BunitContext
 
         cut.Markup.Should().Contain("Read post");
     }
+
+    [Fact]
+    public void Posts_DisplaysSyncProgress_WhenSyncProgressChangedFired()
+    {
+        var cut = Render<Posts>();
+
+        cut.InvokeAsync(() =>
+        {
+            _dataServiceMock.Raise(s => s.SyncProgressChanged += null, new SyncProgressEventArgs(1, 6, "Downloading 1 of 6 posts..."));
+        });
+
+        cut.Markup.Should().Contain("Downloading 1 of 6 posts...");
+        var progress = cut.FindComponent<FluentProgress>();
+        progress.Instance.Value.Should().Be(1);
+        progress.Instance.Max.Should().Be(6);
+    }
+
+    [Fact]
+    public void Posts_DisplaysCleaningStatus_WhenSyncProgressChangedFired()
+    {
+        var cut = Render<Posts>();
+
+        cut.InvokeAsync(() =>
+        {
+            _dataServiceMock.Raise(s => s.SyncProgressChanged += null, new SyncProgressEventArgs(0, 0, "Cleaning..."));
+        });
+
+        cut.Markup.Should().Contain("Cleaning...");
+    }
 }
 

--- a/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
+++ b/src/NoteBookmark.MauiApp.Tests/SyncServiceTests.cs
@@ -466,7 +466,9 @@ public class SyncServiceTests
         await _sut.SyncAsync();
 
         progressEvents.Should().NotBeEmpty();
-        progressEvents.Should().Contain(e => e.Status.Contains("Downloading offline text"));
+        progressEvents.Should().Contain(e => e.Status == "Cleaning...");
+        progressEvents.Should().Contain(e => e.Status == "Downloading 1 of 2 posts..." && e.Current == 1 && e.Total == 2);
+        progressEvents.Should().Contain(e => e.Status == "Downloading 2 of 2 posts..." && e.Current == 2 && e.Total == 2);
         progressEvents.Last().Status.Should().Be("Synchronization complete!");
     }
 }

--- a/src/NoteBookmark.MauiApp/Data/SyncService.cs
+++ b/src/NoteBookmark.MauiApp/Data/SyncService.cs
@@ -243,6 +243,8 @@ public class SyncService(
         var postMap = posts.ToDictionary(p => p.Id ?? p.RowKey);
         var cachedIds = localHtmlStorageService.GetCachedPostIds().ToHashSet();
 
+        SyncProgressChanged?.Invoke(this, new SyncProgressEventArgs(0, 0, "Cleaning..."));
+
         // Prune cached HTML for posts that are read or no longer exist
         foreach (var cachedId in cachedIds)
         {
@@ -258,7 +260,7 @@ public class SyncService(
 
         if (total > 0)
         {
-            SyncProgressChanged?.Invoke(this, new SyncProgressEventArgs(0, total, $"Downloading offline text (0/{total})..."));
+            SyncProgressChanged?.Invoke(this, new SyncProgressEventArgs(0, total, $"Downloading 0 of {total} posts..."));
 
             for (int i = 0; i < unreadToDownload.Count; i++)
             {
@@ -279,7 +281,7 @@ public class SyncService(
                 }
 
                 int current = i + 1;
-                SyncProgressChanged?.Invoke(this, new SyncProgressEventArgs(current, total, $"Downloading offline text ({current}/{total})..."));
+                SyncProgressChanged?.Invoke(this, new SyncProgressEventArgs(current, total, $"Downloading {current} of {total} posts..."));
             }
         }
     }

--- a/src/NoteBookmark.MauiApp/NoteBookmark.MauiApp.csproj
+++ b/src/NoteBookmark.MauiApp/NoteBookmark.MauiApp.csproj
@@ -44,9 +44,9 @@
         <ApplicationId>c5m.notebookmark.mauiapp</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.3.3</ApplicationDisplayVersion>
-        <ApplicationVersion>6</ApplicationVersion>
-        <Version>1.3.3</Version>
+        <ApplicationDisplayVersion>1.4.2</ApplicationDisplayVersion>
+        <ApplicationVersion>7</ApplicationVersion>
+        <Version>1.4.2</Version>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>

--- a/src/NoteBookmark.SharedUI/Components/Pages/PostReader.razor
+++ b/src/NoteBookmark.SharedUI/Components/Pages/PostReader.razor
@@ -9,10 +9,16 @@
 <PageTitle>@(post?.Title ?? "Reading...")</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" Style="width: 100%; max-width: 800px; margin: 0 auto; padding: 1rem; box-sizing: border-box;">
-    <FluentStack Orientation="Orientation.Horizontal">
-        <FluentButton OnClick="@(() => Navigation.NavigateTo("/posts"))"
-                      IconStart="@(new Icons.Regular.Size20.ArrowLeft())"
-                      Title="Back to posts">Back</FluentButton>
+    <FluentStack Orientation="Orientation.Vertical" Style="width: 100%; gap: 0.5rem; margin-bottom: 1rem;">
+        <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
+            <FluentButton OnClick="@(() => Navigation.NavigateTo("/posts"))"
+                          IconStart="@(new Icons.Regular.Size20.ArrowLeft())"
+                          Title="Back to posts">Back</FluentButton>
+            <FluentSpacer />
+            <span style="font-weight: 600;">Text size:</span>
+            <span>@(textSize)px</span>
+        </FluentStack>
+        <FluentSlider Min="8" Max="56" Step="1" @bind-Value="textSize" Style="width: 100%;" aria-label="Text size slider" />
     </FluentStack>
 
     @if (isLoading)
@@ -51,6 +57,10 @@
 
         <FluentStack Orientation="Orientation.Vertical" Style="width: 100%; gap: 0.5rem; margin-top: 1rem;">
             <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
+                <FluentButton OnClick="@(() => Navigation.NavigateTo("/posts"))"
+                              IconStart="@(new Icons.Regular.Size20.ArrowLeft())"
+                              Title="Back to posts">Back</FluentButton>
+                <FluentSpacer />
                 <span style="font-weight: 600;">Text size:</span>
                 <span>@(textSize)px</span>
             </FluentStack>

--- a/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
+++ b/src/NoteBookmark.SharedUI/Components/Pages/Posts.razor
@@ -115,13 +115,21 @@
 
         try
         {
+            isSyncing = true;
             await client.SyncAsync();
             await LoadPosts();
-            StateHasChanged();
         }
         catch (Exception)
         {
             // Ignore background sync errors
+        }
+        finally
+        {
+            isSyncing = false;
+            syncProgressStatus = string.Empty;
+            syncProgressCurrent = 0;
+            syncProgressTotal = 0;
+            StateHasChanged();
         }
     }
 
@@ -287,6 +295,10 @@
         finally
         {
             isSyncing = false;
+            syncProgressStatus = string.Empty;
+            syncProgressCurrent = 0;
+            syncProgressTotal = 0;
+            StateHasChanged();
         }
     }
 


### PR DESCRIPTION
## Summary of Changes

- **Version Bump**: Updated project version to `1.4.2` in `Directory.Build.props` and `src/NoteBookmark.MauiApp/NoteBookmark.MauiApp.csproj`.
- **Sync Progress Reporting**:
  - Enhanced `SyncService` to emit progress updates for cleaning cached HTML and real-time post download counts (`Downloading 1 of X posts...`, `Downloading 2 of X posts...`, etc.).
  - Updated `Posts.razor` to properly track sync state, display the progress bar and status message while sync is in progress, and cleanly dismiss when complete.
- **Reader Page Controls**:
  - Added the Back button and Text Size slider to both the top and bottom of `PostReader.razor`.
- **Unit Tests**:
  - Added unit tests in `PostsTests.cs` verifying sync progress and status display.
  - Updated `SyncServiceTests.cs` asserting cleaning and post download progress events.
  - Updated `PostReaderTests.cs` asserting both top and bottom back buttons and sliders.